### PR TITLE
Able to use '{REMOTE}/{BRANCH}' syntax as source branch

### DIFF
--- a/oca_port/__init__.py
+++ b/oca_port/__init__.py
@@ -59,7 +59,7 @@ from .port_addon_pr import PortAddonPullRequest
               help="Git remote from which source and target branches are fetched by default.")
 @click.option("--repo-name", help="Repository name, eg. server-tools.")
 @click.option("--fork",
-              help="Git remote on which branches containing ported commits are pushed.")
+              help="Git remote where branches with ported commits are pushed.")
 @click.option("--user-org", show_default="--fork", help="User organization name.")
 @click.option("--verbose", is_flag=True,
               help="List the commits of Pull Requests.")
@@ -72,10 +72,17 @@ def main(
     """Migrate ADDON from FROM_BRANCH to TO_BRANCH or list Pull Requests to port
     if ADDON already exists on TO_BRANCH.
 
-    The PRs are found from source branch commits that do not exist in the target branch.
+    Migration:
 
-    If the option `--fork` is set, one branche per PR will be created with
-    missing commits and will be pushed to the indicated fork on GitHub.
+        Assist the user in the migration of the addon, following the OCA guidelines.
+
+    Port of Pull Requests (missing commits):
+
+        The PRs are found from FROM_BRANCH commits that do not exist in TO_BRANCH.
+The user will be asked if he wants to port them.
+
+    To start the migration process, the `--fork` option must be provided in
+order to push the resulting branch on the user's remote.
     """
     repo = git.Repo()
     if repo.is_dirty():

--- a/oca_port/__init__.py
+++ b/oca_port/__init__.py
@@ -56,7 +56,7 @@ from .port_addon_pr import PortAddonPullRequest
 @click.option("--upstream-org", default="OCA", show_default=True,
               help="Upstream organization name.")
 @click.option("--upstream", default="origin", show_default=True, required=True,
-              help="Git remote from which source and target branches are fetched.")
+              help="Git remote from which source and target branches are fetched by default.")
 @click.option("--repo-name", help="Repository name, eg. server-tools.")
 @click.option("--fork",
               help="Git remote on which branches containing ported commits are pushed.")
@@ -84,22 +84,20 @@ def main(
     if not user_org:
         # Assume that the fork remote has the same name than the user organization
         user_org = fork
-    if fork and fork not in repo.remotes:
-        raise click.ClickException(
-            f"No remote {bc.FAIL}{fork}{bc.END} in the current repository.\n"
-            "To add it:\n"
-            f"\t{bc.DIM}$ git remote add {fork} "
-            f"git@github.com:{user_org}/{repo_name}.git{bc.END} "
-            "# This mode requires an SSH key in the GitHub account\n"
-            "Or:\n"
-            f"\t{bc.DIM}$ git remote add {fork} "
-            f"https://github.com/{user_org}/{repo_name}.git{bc.END} "
-            "# This will require to enter user/password each time\n"
-            "\nYou can change the GitHub organization with the "
-            f"{bc.DIM}--user-org{bc.END} option."
-        )
-    from_branch = misc.Branch(repo, from_branch, upstream)
-    to_branch = misc.Branch(repo, to_branch, upstream)
+    if fork:
+        error_msg = _check_remote(repo_name, repo, fork, raise_exc=False)
+        if error_msg:
+            error_msg += (
+                "\n\nYou can change the GitHub organization with the "
+                f"{bc.DIM}--user-org{bc.END} option."
+            )
+            raise click.ClickException(error_msg)
+    try:
+        # Parse source and target branches
+        from_branch = misc.Branch(repo, from_branch, default_remote=upstream)
+        to_branch = misc.Branch(repo, to_branch, default_remote=upstream)
+    except ValueError as exc:
+        _check_remote(repo_name, *exc.args)
     storage = misc.InputStorage(repo.working_dir)
     _fetch_branches(from_branch, to_branch, verbose=verbose)
     _check_branches(from_branch, to_branch)
@@ -117,6 +115,25 @@ def main(
             repo, upstream_org, repo_name, from_branch, to_branch,
             fork, user_org, addon, storage, verbose, non_interactive
         ).run()
+
+
+def _check_remote(repo_name, repo, remote, raise_exc=True):
+    """Check that `remote` exists in the local repository."""
+    if remote not in repo.remotes:
+        msg = (
+            f"No remote {bc.FAIL}{remote}{bc.END} in the current repository.\n"
+            "To add it:\n"
+            "\t# This mode requires an SSH key in the GitHub account\n"
+            f"\t{bc.DIM}$ git remote add {remote} "
+            f"git@github.com:{remote}/{repo_name}.git{bc.END}\n"
+            "   Or:\n"
+            "\t# This will require to enter user/password each time\n"
+            f"\t{bc.DIM}$ git remote add {remote} "
+            f"https://github.com/{remote}/{repo_name}.git{bc.END}"
+        )
+        if not raise_exc:
+            return msg
+        raise click.ClickException(msg)
 
 
 def _fetch_branches(*branches, verbose=False):

--- a/oca_port/misc.py
+++ b/oca_port/misc.py
@@ -43,13 +43,18 @@ class bcolors:
 
 
 class Branch():
-    def __init__(self, repo, name, remote=None):
+    def __init__(self, repo, name, default_remote=None, check_remote=True):
         self.repo = repo
+        if len(name.split("/", 1)) > 1:
+            remote, name = name.split("/", 1)
+        else:
+            remote = default_remote
         self.name = name
         self.remote = None
         if remote:
-            if repo.git.ls_remote("--heads", remote, name):
-                self.remote = remote
+            if check_remote and remote not in repo.remotes:
+                raise ValueError(repo, remote)
+            self.remote = remote
 
     def ref(self):
         ref = self.name


### PR DESCRIPTION
This allows to port a module from a development branch (not yet merged in the upstream repository):
```sh
$ oca-port camptocamp/14.0-mig-my_module 15.0 my_module
```

TODO: check how to improve this integration for source+target branches