### PR TITLE
[IMP] Add user's cache (default to ~/.cache/oca-port/)

### DIFF
--- a/oca_port/__init__.py
+++ b/oca_port/__init__.py
@@ -65,9 +65,10 @@ from .port_addon_pr import PortAddonPullRequest
               help="List the commits of Pull Requests.")
 @click.option("--non-interactive", is_flag=True,
               help="Disable all interactive prompts.")
+@click.option("--no-cache", is_flag=True, help="Disable user's cache.")
 def main(
         from_branch, to_branch, addon, upstream_org, upstream, repo_name,
-        fork, user_org, verbose, non_interactive
+        fork, user_org, verbose, non_interactive, no_cache
         ):
     """Migrate ADDON from FROM_BRANCH to TO_BRANCH or list Pull Requests to port
     if ADDON already exists on TO_BRANCH.
@@ -109,18 +110,21 @@ order to push the resulting branch on the user's remote.
     _check_branches(from_branch, to_branch)
     _check_addon_exists(addon, from_branch, raise_exc=True)
     storage = utils.storage.InputStorage(to_branch, addon)
+    cache = utils.cache.UserCacheFactory(
+        upstream_org, repo_name, addon, from_branch, to_branch, no_cache
+    ).build()
     # Check if the addon (folder) exists on the target branch
     #   - if it already exists, check if some PRs could be ported
     if _check_addon_exists(addon, to_branch):
         PortAddonPullRequest(
             repo, upstream_org, repo_name, from_branch, to_branch,
-            fork, user_org, addon, storage, verbose, non_interactive
+            fork, user_org, addon, storage, cache, verbose, non_interactive
         ).run()
     #   - if not, migrate it
     else:
         MigrateAddon(
             repo, upstream_org, repo_name, from_branch, to_branch,
-            fork, user_org, addon, storage, verbose, non_interactive
+            fork, user_org, addon, storage, cache, verbose, non_interactive
         ).run()
 
 

--- a/oca_port/__init__.py
+++ b/oca_port/__init__.py
@@ -43,8 +43,8 @@ import os
 import click
 import git
 
-from . import misc
-from .misc import bcolors as bc
+from . import utils
+from .utils.misc import bcolors as bc
 from .migrate_addon import MigrateAddon
 from .port_addon_pr import PortAddonPullRequest
 
@@ -101,14 +101,14 @@ order to push the resulting branch on the user's remote.
             raise click.ClickException(error_msg)
     try:
         # Parse source and target branches
-        from_branch = misc.Branch(repo, from_branch, default_remote=upstream)
-        to_branch = misc.Branch(repo, to_branch, default_remote=upstream)
+        from_branch = utils.git.Branch(repo, from_branch, default_remote=upstream)
+        to_branch = utils.git.Branch(repo, to_branch, default_remote=upstream)
     except ValueError as exc:
         _check_remote(repo_name, *exc.args)
     _fetch_branches(from_branch, to_branch, verbose=verbose)
     _check_branches(from_branch, to_branch)
     _check_addon_exists(addon, from_branch, raise_exc=True)
-    storage = misc.InputStorage(to_branch, addon)
+    storage = utils.storage.InputStorage(to_branch, addon)
     # Check if the addon (folder) exists on the target branch
     #   - if it already exists, check if some PRs could be ported
     if _check_addon_exists(addon, to_branch):

--- a/oca_port/__init__.py
+++ b/oca_port/__init__.py
@@ -66,9 +66,10 @@ from .port_addon_pr import PortAddonPullRequest
 @click.option("--non-interactive", is_flag=True,
               help="Disable all interactive prompts.")
 @click.option("--no-cache", is_flag=True, help="Disable user's cache.")
+@click.option("--clear-cache", is_flag=True, help="Clear the user's cache.")
 def main(
         from_branch, to_branch, addon, upstream_org, upstream, repo_name,
-        fork, user_org, verbose, non_interactive, no_cache
+        fork, user_org, verbose, non_interactive, no_cache, clear_cache
         ):
     """Migrate ADDON from FROM_BRANCH to TO_BRANCH or list Pull Requests to port
     if ADDON already exists on TO_BRANCH.
@@ -126,6 +127,8 @@ order to push the resulting branch on the user's remote.
             repo, upstream_org, repo_name, from_branch, to_branch,
             fork, user_org, addon, storage, cache, verbose, non_interactive
         ).run()
+    if clear_cache:
+        cache.clear()
 
 
 def _check_remote(repo_name, repo, remote, raise_exc=True):

--- a/oca_port/migrate_addon.py
+++ b/oca_port/migrate_addon.py
@@ -6,8 +6,8 @@ import os
 import tempfile
 import urllib.parse
 
-from . import misc
-from .misc import bcolors as bc
+from .utils import misc, git as g
+from .utils.misc import bcolors as bc
 from .port_addon_pr import PortAddonPullRequest
 
 MIG_BRANCH_NAME = (
@@ -72,7 +72,7 @@ class MigrateAddon():
         self.user_org = user_org
         self.addon = addon
         self.storage = storage
-        self.mig_branch = misc.Branch(
+        self.mig_branch = g.Branch(
             repo, MIG_BRANCH_NAME.format(branch=to_branch.name[:4], addon=addon)
         )
         self.verbose = verbose
@@ -114,7 +114,7 @@ class MigrateAddon():
             with tempfile.TemporaryDirectory() as patches_dir:
                 self._generate_patches(patches_dir)
                 self._apply_patches(patches_dir)
-            misc.run_pre_commit(self.repo, self.addon)
+            g.run_pre_commit(self.repo, self.addon)
         # Check if the addon has commits that update neighboring addons to
         # make it work properly
         PortAddonPullRequest(

--- a/oca_port/migrate_addon.py
+++ b/oca_port/migrate_addon.py
@@ -61,7 +61,8 @@ BLACKLIST_TIPS = "\n".join([
 class MigrateAddon():
     def __init__(
             self, repo, upstream_org, repo_name, from_branch, to_branch,
-            fork, user_org, addon, storage, verbose=False, non_interactive=False
+            fork, user_org, addon, storage, cache=None, verbose=False,
+            non_interactive=False
             ):
         self.repo = repo
         self.upstream_org = upstream_org
@@ -72,6 +73,7 @@ class MigrateAddon():
         self.user_org = user_org
         self.addon = addon
         self.storage = storage
+        self.cache = cache
         self.mig_branch = g.Branch(
             repo, MIG_BRANCH_NAME.format(branch=to_branch.name[:4], addon=addon)
         )
@@ -120,7 +122,7 @@ class MigrateAddon():
         PortAddonPullRequest(
             self.repo, self.upstream_org, self.repo_name,
             self.from_branch, self.mig_branch, self.fork, self.user_org,
-            self.addon, self.storage, self.verbose,
+            self.addon, self.storage, self.cache, self.verbose,
             create_branch=False, push_branch=False
         ).run()
         self._print_tips()

--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -41,6 +41,9 @@ FILES_TO_KEEP = [
     "oca_dependencies.txt",
 ]
 
+# Fake PR for commits w/o any PR (used as fallback)
+FAKE_PR = g.PullRequest(*[""] * 6)
+
 
 def path_to_skip(commit_path):
     """Return True if the commit path should not be ported."""
@@ -509,107 +512,82 @@ class BranchesDiff():
         :return: a dict {PullRequest: {Commit: data, ...}, ...}
         """
         commits_by_pr = defaultdict(list)
-        # Fake PR for commits w/o related PR
-        fake_pr = g.PullRequest(*[""] * 6, tuple(), tuple())
         for commit in self.from_branch_path_commits:
             if commit in self.to_branch_all_commits:
                 self.cache.mark_commit_as_ported(commit.hexsha)
                 continue
             # Get related Pull Request if any
-            if any("github.com" in remote.url for remote in self.repo.remotes):
-                gh_commit_pulls = github.request(
-                    f"repos/{self.upstream_org}/{self.repo_name}"
-                    f"/commits/{commit.hexsha}/pulls"
-                )
-                full_repo_name = f"{self.upstream_org}/{self.repo_name}"
-                gh_commit_pull = [
-                    data for data in gh_commit_pulls
-                    if data["base"]["repo"]["full_name"] == full_repo_name
-                ]
-                if gh_commit_pull:
-                    pr = self._new_pull_request_from_github_data(gh_commit_pull[0])
-                    # Get all commits of the related PR as they could update
-                    # others addons than the one the user is interested in
-                    # NOTE: commits fetched from PR are already in the right order
-                    gh_pr_commits = github.request(
-                        f"repos/{self.upstream_org}/{self.repo_name}"
-                        f"/pulls/{pr.number}/commits"
+            pr = self._get_original_pr(commit)
+            if pr:
+                for pr_commit_sha in pr.commits:
+                    try:
+                        raw_commit = self.repo.commit(pr_commit_sha)
+                    except ValueError:
+                        # Ignore commits referenced by a PR but not present
+                        # in the stable branches
+                        continue
+                    pr_commit = g.Commit(raw_commit)
+                    if self._skip_commit(pr_commit):
+                        continue
+                    pr_commit_paths = set(
+                        path for path in pr_commit.paths
+                        if not path_to_skip(path)
                     )
-                    # TODO cache PR data to not request GH several times
-                    #   => commits of a merged PR can't change anymore, it's OK
-                    #   to cache this
-                    for gh_pr_commit in gh_pr_commits:
-                        try:
-                            raw_commit = self.repo.commit(gh_pr_commit["sha"])
-                        except ValueError:
-                            # Ignore commits referenced by a PR but not present
-                            # in the stable branches
+                    pr.paths.update(pr_commit_paths)
+                    # Check that this PR commit does not change the current
+                    # addon we are interested in, in such case also check
+                    # for each updated addons that the commit has already
+                    # been ported.
+                    # Indeed a commit could have been ported partially
+                    # in the past (with git-format-patch), and we now want
+                    # to port the remaining chunks.
+                    if pr_commit not in self.to_branch_path_commits:
+                        paths = set(pr_commit_paths)
+                        # A commit could have been ported several times
+                        # if it was impacting several addons and the
+                        # migration has been done with git-format-patch
+                        # on each addon separately
+                        to_branch_all_commits = self.to_branch_all_commits[:]
+                        skip_pr_commit = False
+                        with g.no_strict_commit_equality():
+                            while pr_commit in to_branch_all_commits:
+                                index = to_branch_all_commits.index(pr_commit)
+                                ported_commit = to_branch_all_commits.pop(index)
+                                ported_commit_paths = set(
+                                    path for path in ported_commit.paths
+                                    if not path_to_skip(path)
+                                )
+                                pr.ported_paths.update(ported_commit_paths)
+                                pr_commit.ported_commits.append(ported_commit)
+                                paths -= ported_commit_paths
+                                if not paths:
+                                    # The ported commits have already updated
+                                    # the same addons than the original one,
+                                    # we can skip it.
+                                    skip_pr_commit = True
+                        if skip_pr_commit:
                             continue
-                        pr_commit = g.Commit(raw_commit)
-                        if self._skip_commit(pr_commit):
-                            continue
-                        pr_commit_paths = set(
-                            path for path in pr_commit.paths
-                            if not path_to_skip(path)
-                        )
-                        pr.paths.update(pr_commit_paths)
-                        # Check that this PR commit does not change the current
-                        # addon we are interested in, in such case also check
-                        # for each updated addons that the commit has already
-                        # been ported.
-                        # Indeed a commit could have been ported partially
-                        # in the past (with git-format-patch), and we now want
-                        # to port the remaining chunks.
-                        if pr_commit not in self.to_branch_path_commits:
-                            paths = set(pr_commit_paths)
-                            # A commit could have been ported several times
-                            # if it was impacting several addons and the
-                            # migration has been done with git-format-patch
-                            # on each addon separately
-                            to_branch_all_commits = self.to_branch_all_commits[:]
-                            skip_pr_commit = False
-                            with g.no_strict_commit_equality():
-                                while pr_commit in to_branch_all_commits:
-                                    index = to_branch_all_commits.index(pr_commit)
-                                    ported_commit = to_branch_all_commits.pop(index)
-                                    ported_commit_paths = set(
-                                        path for path in ported_commit.paths
-                                        if not path_to_skip(path)
-                                    )
-                                    pr.ported_paths.update(ported_commit_paths)
-                                    pr_commit.ported_commits.append(ported_commit)
-                                    paths -= ported_commit_paths
-                                    if not paths:
-                                        # The ported commits have already updated
-                                        # the same addons than the original one,
-                                        # we can skip it.
-                                        skip_pr_commit = True
-                            if skip_pr_commit:
-                                continue
-                        # We want to port commits that were still not ported
-                        # for the addon we are interested in.
-                        # If the commit has already been included, skip it.
+                    # We want to port commits that were still not ported
+                    # for the addon we are interested in.
+                    # If the commit has already been included, skip it.
+                    if (
+                            pr_commit in self.to_branch_path_commits
+                            and pr_commit in self.to_branch_all_commits
+                    ):
+                        continue
+                    existing_pr_commits = commits_by_pr.get(pr, [])
+                    for existing_pr_commit in existing_pr_commits:
                         if (
-                                pr_commit in self.to_branch_path_commits
-                                and pr_commit in self.to_branch_all_commits
+                            existing_pr_commit == pr_commit and
+                            existing_pr_commit.hexsha == pr_commit.hexsha
                         ):
-                            continue
-                        existing_pr_commits = commits_by_pr.get(pr, [])
-                        for existing_pr_commit in existing_pr_commits:
-                            if (
-                                existing_pr_commit == pr_commit and
-                                existing_pr_commit.hexsha == pr_commit.hexsha
-                            ):
-                                # This PR commit has already been appended, skip
-                                break
-                        else:
-                            commits_by_pr[pr].append(pr_commit)
-                # No related PR: add the commit to the fake PR
-                else:
-                    commits_by_pr[fake_pr].append(commit)
+                            # This PR commit has already been appended, skip
+                            break
+                    else:
+                        commits_by_pr[pr].append(pr_commit)
+            # No related PR: add the commit to the fake PR
             else:
-                # FIXME log?
-                pass
+                commits_by_pr[FAKE_PR].append(commit)
         # Sort PRs on the merge date (better to port them in the right order).
         # Do not return blacklisted PR.
         sorted_commits_by_pr = {}
@@ -625,22 +603,36 @@ class BranchesDiff():
             sorted_commits_by_pr[pr] = commits_by_pr[pr]
         return sorted_commits_by_pr
 
-    @staticmethod
-    def _new_pull_request_from_github_data(data, paths=None, ported_paths=None):
-        """Create a new PullRequest instance from GitHub data."""
-        pr_number = data["number"]
-        pr_url = data["html_url"]
-        pr_author = data["user"].get("login", "")
-        pr_title = data["title"]
-        pr_body = data["body"]
-        pr_merge_at = data["merged_at"]
-        return g.PullRequest(
-            number=pr_number,
-            url=pr_url,
-            author=pr_author,
-            title=pr_title,
-            body=pr_body,
-            merged_at=pr_merge_at,
-            paths=paths,
-            ported_paths=ported_paths,
+    def _get_original_pr(self, commit: g.Commit):
+        """Return the original PR of a given commit."""
+        # TODO cache PR data to not request GH several times
+        #   => commits of a merged PR can't change anymore, it's OK to cache this
+        if not any("github.com" in remote.url for remote in self.repo.remotes):
+            return
+        data = github.get_original_pr(
+            self.upstream_org, self.repo_name, self.from_branch.name, commit.hexsha
         )
+        if data:
+            pr_number = data["number"]
+            pr_url = data["html_url"]
+            pr_author = data["user"].get("login", "")
+            pr_title = data["title"]
+            pr_body = data["body"]
+            pr_merge_at = data["merged_at"]
+            # Get all commits of the PR as they could update others addons
+            # than the one the user is interested in.
+            # NOTE: commits fetched from PR are already in the right order
+            pr_commits_data = github.request(
+                f"repos/{self.upstream_org}/{self.repo_name}"
+                f"/pulls/{pr_number}/commits"
+            )
+            pr_commits = [pr["sha"] for pr in pr_commits_data]
+            return g.PullRequest(
+                number=pr_number,
+                url=pr_url,
+                author=pr_author,
+                title=pr_title,
+                body=pr_body,
+                merged_at=pr_merge_at,
+                commits=pr_commits,
+            )

--- a/oca_port/utils/__init__.py
+++ b/oca_port/utils/__init__.py
@@ -2,3 +2,5 @@ from . import git
 from . import github
 from . import misc
 from . import storage
+from . import cache
+from . import git

--- a/oca_port/utils/__init__.py
+++ b/oca_port/utils/__init__.py
@@ -1,0 +1,4 @@
+from . import git
+from . import github
+from . import misc
+from . import storage

--- a/oca_port/utils/cache.py
+++ b/oca_port/utils/cache.py
@@ -1,0 +1,127 @@
+# Copyright 2022 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
+
+import logging
+import pathlib
+import os
+
+from . import git as g
+
+
+_logger = logging.getLogger(__name__)
+
+
+class UserCacheFactory():
+    """User's cache manager factory."""
+    def __init__(
+            self, upstream_org: str, repo_name: str, addon:str ,
+            from_branch: g.Branch, to_branch: g.Branch, no_cache: bool
+        ):
+        self._upstream_org = upstream_org
+        self._repo_name = repo_name
+        self._addon = addon
+        self._from_branch = from_branch
+        self._to_branch = to_branch
+        self._no_cache = no_cache
+
+    def build(self):
+        """Build the cache manager."""
+        if self._no_cache:
+            return NoCache()
+        try:
+            cache = UserCache(
+                self._upstream_org, self._repo_name, self._addon,
+                self._from_branch, self._to_branch
+            )
+        except:
+            # If the cache can't be used (whatever the reason) we fallback on a
+            # fake-cache manager.
+            _logger.warning(
+                "No cache will be used: unable to initialize the cache folder in %s.",
+                UserCache._get_dir_path()
+            )
+            cache = NoCache()
+        return cache
+
+
+class NoCache():
+    """Fake cache manager class.
+
+    Used if the cache can't be used, e.g. no write access to cache folder.
+    """
+    def __init__(*args, **kwargs):
+        """Initialize a fake user's cache manager."""
+        pass
+
+    def mark_commit_as_ported(self, commit_sha):
+        # Do nothing
+        pass
+
+    def is_commit_ported(self, commit_sha):
+        # A commit is always considered as not ported
+        return False
+
+
+class UserCache():
+    """Manage the user's cache, in respect to XDG conventions.
+
+    This class manages the following data:
+        - a list of already ported commits from one branch to another.
+
+    It allows to speed up further commit scans on a given module.
+    """
+    _cache_dirname = "oca-port"
+    _ported_dirname = "ported"
+
+    def __init__(
+            self, upstream_org: str, repo_name: str, addon: str,
+            from_branch: g.Branch, to_branch: g.Branch
+        ):
+        """Initialize user's cache manager."""
+        self._upstream_org = upstream_org
+        self._repo_name = repo_name
+        self._addon = addon
+        self._from_branch = from_branch
+        self._to_branch = to_branch
+        self.dir_path = self._get_dir_path()
+        self._ported_commits_path = self._get_ported_commits_path()
+        self._ported_commits = self._get_ported_commits()
+
+    @classmethod
+    def _get_dir_path(cls):
+        """Return the path of the cache directory."""
+        default_cache_dir_path = pathlib.Path.home().joinpath(".cache")
+        return pathlib.Path(
+            os.environ.get('XDG_CACHE_HOME', default_cache_dir_path),
+            cls._cache_dirname
+        )
+
+    def _get_ported_commits_path(self):
+        """Return the file path storing ported commit."""
+        file_name = (
+            f"{self._addon}_{self._from_branch.name}_"
+            f"to_{self._to_branch.name}.list"
+        )
+        return self.dir_path.joinpath(
+            self._ported_dirname,
+            self._upstream_org,
+            self._repo_name,
+            file_name
+        )
+
+    def _get_ported_commits(self):
+        self._ported_commits_path.parent.mkdir(parents=True, exist_ok=True)
+        self._ported_commits_path.touch(exist_ok=True)
+        return self._ported_commits_path.read_text().splitlines()
+
+    def mark_commit_as_ported(self, commit_sha: str):
+        """Mark commit as ported."""
+        if self.is_commit_ported(commit_sha):
+            return
+        self._ported_commits.append(commit_sha)
+        with self._ported_commits_path.open(mode="a") as file_:
+            file_.write(f"{commit_sha}\n")
+
+    def is_commit_ported(self, commit_sha: str):
+        """Return `True` if commit is already ported."""
+        return commit_sha in self._ported_commits

--- a/oca_port/utils/cache.py
+++ b/oca_port/utils/cache.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import json
 import logging
 import pathlib
+import shutil
 import os
 
 from . import git as g, misc
@@ -70,6 +71,10 @@ class NoCache():
     def get_pr_from_commit(self, commit_sha: str):
         # No PR data to return
         return {}
+
+    def clear(self):
+        # Do nothing
+        pass
 
 
 class UserCache():
@@ -182,3 +187,8 @@ class UserCache():
         if pr_number:
             return self._commits_to_port["pull_requests"][str(pr_number)]
         return {}
+
+    def clear(self):
+        """Clear the cache by removing the content of the cache directory."""
+        if self._cache_dirname and str(self.dir_path).endswith(self._cache_dirname):
+            shutil.rmtree(self.dir_path)

--- a/oca_port/utils/git.py
+++ b/oca_port/utils/git.py
@@ -185,7 +185,7 @@ class PullRequest(abc.Hashable):
     eq_attrs = ("number", "url", "author", "title", "body", "merged_at")
 
     def __init__(
-            self, number, url, author, title, body, merged_at,
+            self, number, url, author, title, body, merged_at, commits=None,
             paths=None, ported_paths=None
             ):
         self.number = number
@@ -194,6 +194,7 @@ class PullRequest(abc.Hashable):
         self.title = title
         self.body = body
         self.merged_at = merged_at
+        self.commits = commits if commits else []
         self.paths = set(paths) if paths else set()
         self.ported_paths = set(ported_paths) if ported_paths else set()
 

--- a/oca_port/utils/github.py
+++ b/oca_port/utils/github.py
@@ -1,0 +1,27 @@
+# Copyright 2022 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
+
+import os
+
+import requests
+
+
+GITHUB_API_URL = "https://api.github.com"
+
+
+def request(url, method="get", params=None, json=None):
+    """Request GitHub API."""
+    headers = {"Accept": "application/vnd.github.groot-preview+json"}
+    if os.environ.get("GITHUB_TOKEN"):
+        token = os.environ.get("GITHUB_TOKEN")
+        headers.update({"Authorization": f"token {token}"})
+    full_url = "/".join([GITHUB_API_URL, url])
+    kwargs = {"headers": headers}
+    if json:
+        kwargs.update(json=json)
+    if params:
+        kwargs.update(params=params)
+    response = getattr(requests, method)(full_url, **kwargs)
+    if not response.ok:
+        raise RuntimeError(response.text)
+    return response.json()

--- a/oca_port/utils/github.py
+++ b/oca_port/utils/github.py
@@ -25,3 +25,18 @@ def request(url, method="get", params=None, json=None):
     if not response.ok:
         raise RuntimeError(response.text)
     return response.json()
+
+
+def get_original_pr(upstream_org: str, repo_name: str, branch: str, commit_sha: str):
+    """Return original GitHub PR data of a commit."""
+    gh_commit_pulls = request(
+        f"repos/{upstream_org}/{repo_name}/commits/{commit_sha}/pulls"
+    )
+    gh_commit_pull = [
+        data for data in gh_commit_pulls
+        if (
+            data["base"]["ref"] == branch
+            and data["base"]["repo"]["full_name"] == f"{upstream_org}/{repo_name}"
+        )
+    ]
+    return gh_commit_pull and gh_commit_pull[0] or {}

--- a/oca_port/utils/misc.py
+++ b/oca_port/utils/misc.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Camptocamp SA
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
 
+from collections import defaultdict
 import re
 import os
 
@@ -33,3 +34,10 @@ class bcolors:
 def clean_text(text):
     """Clean text by removing patterns like '13.0', '[13.0]' or '[IMP]'."""
     return re.sub(r"\[.*\]|\d+\.\d+", "", text).strip()
+
+
+def defaultdict_from_dict(d):
+    nd = lambda: defaultdict(nd)    # noqa
+    ni = nd()
+    ni.update(d)
+    return ni

--- a/oca_port/utils/misc.py
+++ b/oca_port/utils/misc.py
@@ -1,0 +1,35 @@
+# Copyright 2022 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
+
+import re
+import os
+
+MANIFEST_NAMES = ("__manifest__.py", "__openerp__.py")
+
+
+# Copy-pasted from OCA/maintainer-tools
+def get_manifest_path(addon_dir):
+    for manifest_name in MANIFEST_NAMES:
+        manifest_path = os.path.join(addon_dir, manifest_name)
+        if os.path.isfile(manifest_path):
+            return manifest_path
+
+
+class bcolors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = '\033[96m'
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[39m"
+    BOLD = "\033[1m"
+    DIM = "\033[2m"
+    ENDD = "\033[22m"
+    UNDERLINE = "\033[4m"
+    END = "\033[0m"
+
+
+def clean_text(text):
+    """Clean text by removing patterns like '13.0', '[13.0]' or '[IMP]'."""
+    return re.sub(r"\[.*\]|\d+\.\d+", "", text).strip()

--- a/oca_port/utils/storage.py
+++ b/oca_port/utils/storage.py
@@ -7,7 +7,7 @@ import os
 
 import click
 
-from . import git as g
+from . import git as g, misc
 
 
 class InputStorage():
@@ -49,19 +49,12 @@ class InputStorage():
         If a JSON file is found, return its content, otherwise return an empty
         dictionary.
         """
-
-        def defaultdict_from_dict(d):
-            nd = lambda: defaultdict(nd)    # noqa
-            ni = nd()
-            ni.update(d)
-            return ni
-
         try:
             # Read the JSON file from 'to_branch'
             tree = self.repo.commit(self.to_branch.ref()).tree
             blob = tree/self.storage_dirname/"blacklist"/f"{self.addon}.json"
             content = blob.data_stream.read().decode()
-            return json.loads(content, object_hook=defaultdict_from_dict)
+            return json.loads(content, object_hook=misc.defaultdict_from_dict)
         except KeyError:
             nested_dict = lambda: defaultdict(nested_dict)  # noqa
             return nested_dict()

--- a/oca_port/utils/storage.py
+++ b/oca_port/utils/storage.py
@@ -1,0 +1,133 @@
+# Copyright 2022 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
+
+from collections import defaultdict
+import json
+import os
+
+import click
+
+from . import git as g
+
+
+class InputStorage():
+    """Store the user inputs related to an addon.
+
+    If commits/pull requests of an addon may be ported, some of them could be
+    false-positive and as such the user can choose to not port them.
+    This class will help to store these informations so the tool won't list
+    anymore these commits the next time we perform an analysis on the same addon.
+
+    Technically the data are stored in one JSON file per addon in a hidden
+    folder at the root of the repository. E.g:
+
+        {
+          "no_migration": "included in standard"
+        }
+
+    Or:
+
+        {
+          "pull_requests": {
+            490: "lint changes"
+          }
+        }
+    """
+    storage_dirname = ".oca/oca-port"
+
+    def __init__(self, to_branch, addon):
+        self.to_branch = to_branch
+        self.repo = self.to_branch.repo
+        self.root_path = self.repo.working_dir
+        self.addon = addon
+        self._data = self._get_data()
+        self.dirty = False
+
+    def _get_data(self):
+        """Return the data of the current repository.
+
+        If a JSON file is found, return its content, otherwise return an empty
+        dictionary.
+        """
+
+        def defaultdict_from_dict(d):
+            nd = lambda: defaultdict(nd)    # noqa
+            ni = nd()
+            ni.update(d)
+            return ni
+
+        try:
+            # Read the JSON file from 'to_branch'
+            tree = self.repo.commit(self.to_branch.ref()).tree
+            blob = tree/self.storage_dirname/"blacklist"/f"{self.addon}.json"
+            content = blob.data_stream.read().decode()
+            return json.loads(content, object_hook=defaultdict_from_dict)
+        except KeyError:
+            nested_dict = lambda: defaultdict(nested_dict)  # noqa
+            return nested_dict()
+
+    def save(self):
+        """Store the data at the root of the current repository."""
+        if not self._data or not self.dirty:
+            return False
+        file_path = self._get_file_path()
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        with open(file_path, "w") as file_:
+            json.dump(self._data, file_, indent=2)
+        return True
+
+    def _get_file_path(self):
+        return os.path.join(
+            self.root_path, self.storage_dirname, "blacklist", f"{self.addon}.json"
+        )
+
+    def is_pr_blacklisted(self, pr_ref):
+        pr_ref = str(pr_ref or "orphaned_commits")
+        return self._data.get("pull_requests", {}).get(pr_ref, False)
+
+    def blacklist_pr(self, pr_ref, confirm=False, reason=None):
+        if confirm and not click.confirm("\tBlacklist this PR?"):
+            return
+        if not reason:
+            reason = click.prompt("\tReason", type=str)
+        pr_ref = str(pr_ref or "orphaned_commits")
+        self._data["pull_requests"][pr_ref] = reason or "Unknown"
+        self.dirty = True
+
+    def is_addon_blacklisted(self):
+        entry = self._data.get("no_migration")
+        if entry:
+            return entry
+        return False
+
+    def blacklist_addon(self, confirm=False, reason=None):
+        if confirm and not click.confirm("\tBlacklist this module?"):
+            return
+        if not reason:
+            reason = click.prompt("Reason", type=str)
+        self._data["no_migration"] = reason or "Unknown"
+        self.dirty = True
+
+    def commit(self):
+        """Commit all files contained in the storage directory."""
+        if not self.save():
+            return
+        changed_paths = g.get_changed_paths(self.repo)
+        all_in_storage = all(
+            path.startswith(self.storage_dirname) for path in changed_paths
+        )
+        if self.repo.is_dirty() and not all_in_storage:
+            raise click.ClickException(
+                "changes not committed detected in this repository."
+            )
+        # Ensure to be on a dedicated branch
+        if self.repo.active_branch.name == self.to_branch.name:
+            raise click.ClickException(
+                "performing commit on upstream branch is not allowed."
+            )
+        # Commit all changes under ./.oca-port
+        self.repo.index.add(self.storage_dirname)
+        if self.repo.is_dirty():
+            g.run_pre_commit(self.repo, self.addon, commit=False, hook="prettier")
+            self.repo.index.commit(f"oca-port: store '{self.addon}' data")
+            self.dirty = False


### PR DESCRIPTION
- Explode `oca_port.misc` to several `oca_port.utils.*` modules
- Put ported commits & PR data in cache

This allows to speed up the time needed by `oca-port` (~50%) to analyse commits to port for a given module if the command already run in the past by doing two things:

- skip commits already ported (no `Commit` objects creation and no check against its sibling on the target branch)
- avoid HTTP requests against GitHub API by caching their results

The user's cache folder used respect the `$XDG_CACHE_HOME` environment variable, and default to `$HOME/.cache/`.
The cache can also be disabled on demand with the `--no-cache` CLI option:

```sh
$ oca-port [...] --no-cache
```