### PR TITLE
Make 'oca-port' available as a Python package + JSON output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: tests
+
+on: [pull_request, push]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install .[test]
+          sudo apt install -y git
+          git config --global user.email "oca-port@example.com"
+          git config --global user.name "oca-port-test"
+      - name: Run tests
+        run: pytest tests

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ performed automatically.
 **Output example:**
 ![image](https://user-images.githubusercontent.com/5315285/129355442-f863adff-33c0-4c91-b0cb-b6882312e340.png)
 
+If used with the `--non-interactive` option, the returned exit code is `100`
+if an addon could be migrated.
+
 Port of commits/Pull Requests
 -----------------------------
 
@@ -59,3 +62,6 @@ More details here : [OCA Days 2022 - Sébastien Alix and Simone Orsi: oca-port:n
 
 **Output example (with --verbose):**
 ![oca_port_pr_verbose](https://user-images.githubusercontent.com/5315285/129207041-12ac6c4a-ea96-4b8c-bd68-ae661531ad92.png)
+
+If used with the `--non-interactive` option, the returned exit code is `110`
+if some pull requests/commits could be ported.

--- a/oca_port/__init__.py
+++ b/oca_port/__init__.py
@@ -38,7 +38,9 @@ base the next PR on the previous one, allowing the user to cumulate ported PRs
 in one branch and creating a draft PR against the upstream repository with all
 of them.
 """
+import pathlib
 import os
+from dataclasses import dataclass
 
 import click
 import git
@@ -47,6 +49,8 @@ from . import utils
 from .migrate_addon import MigrateAddon
 from .port_addon_pr import PortAddonPullRequest
 from .utils.misc import bcolors as bc
+from .utils.git import Branch
+from .exceptions import ForkValueError, RemoteBranchValueError
 
 
 @click.command()
@@ -78,18 +82,18 @@ from .utils.misc import bcolors as bc
 @click.option("--no-cache", is_flag=True, help="Disable user's cache.")
 @click.option("--clear-cache", is_flag=True, help="Clear the user's cache.")
 def main(
-    from_branch,
-    to_branch,
-    addon,
-    upstream_org,
-    upstream,
-    repo_name,
-    fork,
-    user_org,
-    verbose,
-    non_interactive,
-    no_cache,
-    clear_cache,
+    from_branch: str,
+    to_branch: str,
+    addon: str,
+    upstream_org: str,
+    upstream: str,
+    repo_name: str,
+    fork: str,
+    user_org: str,
+    verbose: bool,
+    non_interactive: bool,
+    no_cache: bool,
+    clear_cache: bool,
 ):
     """Migrate ADDON from FROM_BRANCH to TO_BRANCH or list Pull Requests to port
         if ADDON already exists on TO_BRANCH.
@@ -106,129 +110,199 @@ def main(
         To start the migration process, the `--fork` option must be provided in
     order to push the resulting branch on the user's remote.
     """
-    repo = git.Repo()
-    if repo.is_dirty(untracked_files=True):
-        raise click.ClickException("changes not committed detected in this repository.")
-    repo_name = repo_name or os.path.basename(os.getcwd())
-    if not user_org:
-        # Assume that the fork remote has the same name than the user organization
-        user_org = fork
-    if fork:
-        error_msg = _check_remote(repo_name, repo, fork, raise_exc=False)
-        if error_msg:
-            error_msg += (
-                "\n\nYou can change the GitHub organization with the "
-                f"{bc.DIM}--user-org{bc.END} option."
-            )
-            raise click.ClickException(error_msg)
     try:
-        # Parse source and target branches
-        from_branch = utils.git.Branch(repo, from_branch, default_remote=upstream)
-        to_branch = utils.git.Branch(repo, to_branch, default_remote=upstream)
+        app = App(
+            from_branch=from_branch,
+            to_branch=to_branch,
+            addon=addon,
+            upstream_org=upstream_org,
+            upstream=upstream,
+            repo_path=os.getcwd(),
+            repo_name=repo_name,
+            fork=fork,
+            user_org=user_org,
+            verbose=verbose,
+            non_interactive=non_interactive,
+            no_cache=no_cache,
+            clear_cache=clear_cache,
+        )
+    except ForkValueError as exc:
+        error_msg = prepare_remote_error_msg(*exc.args)
+        error_msg += (
+            "\n\nYou can change the GitHub organization with the "
+            f"{bc.DIM}--user-org{bc.END} option."
+        )
+        raise click.ClickException(error_msg) from exc
+    except RemoteBranchValueError as exc:
+        error_msg = prepare_remote_error_msg(*exc.args)
+        raise click.ClickException(error_msg) from exc
+    except ValueError:
+        raise
+    # Run the app
+    try:
+        app.run()
     except ValueError as exc:
-        _check_remote(repo_name, *exc.args)
-    _fetch_branches(from_branch, to_branch, verbose=verbose)
-    _check_branches(from_branch, to_branch)
-    _check_addon_exists(addon, from_branch, raise_exc=True)
-    storage = utils.storage.InputStorage(to_branch, addon)
-    cache = utils.cache.UserCacheFactory(
-        upstream_org, repo_name, addon, from_branch, to_branch, no_cache
-    ).build()
-    # Check if the addon (folder) exists on the target branch
-    #   - if it already exists, check if some PRs could be ported
-    if _check_addon_exists(addon, to_branch):
-        PortAddonPullRequest(
-            repo,
-            upstream_org,
-            repo_name,
-            from_branch,
-            to_branch,
-            fork,
-            user_org,
-            addon,
-            storage,
-            cache,
-            verbose,
-            non_interactive,
-        ).run()
-    #   - if not, migrate it
-    else:
-        MigrateAddon(
-            repo,
-            upstream_org,
-            repo_name,
-            from_branch,
-            to_branch,
-            fork,
-            user_org,
-            addon,
-            storage,
-            cache,
-            verbose,
-            non_interactive,
-        ).run()
-    if clear_cache:
-        cache.clear()
+        raise click.ClickException(exc) from exc
 
 
-def _check_remote(repo_name, repo, remote, raise_exc=True):
-    """Check that `remote` exists in the local repository."""
-    if remote not in repo.remotes:
-        msg = (
-            f"No remote {bc.FAIL}{remote}{bc.END} in the current repository.\n"
-            "To add it:\n"
-            "\t# This mode requires an SSH key in the GitHub account\n"
-            f"\t{bc.DIM}$ git remote add {remote} "
-            f"git@github.com:{remote}/{repo_name}.git{bc.END}\n"
-            "   Or:\n"
-            "\t# This will require to enter user/password each time\n"
-            f"\t{bc.DIM}$ git remote add {remote} "
-            f"https://github.com/{remote}/{repo_name}.git{bc.END}"
-        )
-        if not raise_exc:
-            return msg
-        raise click.ClickException(msg)
-
-
-def _fetch_branches(*branches, verbose=False):
-    """Fetch `branches`."""
-    for branch in branches:
-        if not branch.remote:
-            continue
-        remote_url = branch.repo.remotes[branch.remote].url
-        if verbose:
-            print(f"Fetch {bc.BOLD}{branch.ref()}{bc.END} from {remote_url}")
-        branch.repo.remotes[branch.remote].fetch(branch.name)
-
-
-def _check_branches(from_branch, to_branch):
-    """Check that all required branches exist in the current repository."""
-    # Check if the source branch exists (required)
-    if not from_branch.remote:
-        raise click.ClickException(
-            f"No source branch {bc.BOLD}{from_branch.ref()}{bc.END} available."
-        )
-    # Check if the target branch exists (with or w/o remote, allowing to work
-    # on a local one)
-    if not to_branch.remote and to_branch.name not in to_branch.repo.heads:
-        raise click.ClickException(
-            f"No target branch {bc.BOLD}{to_branch.name}{bc.END} or "
-            f"{bc.BOLD}{to_branch.ref()}{bc.END} available locally."
-        )
-    return True
-
-
-def _check_addon_exists(addon, branch, raise_exc=False):
-    """Check that `addon` exists on `branch`."""
-    branch_addons = [t.path for t in branch.repo.commit(branch.ref()).tree.trees]
-    if addon not in branch_addons:
-        if not raise_exc:
-            return False
-        raise click.ClickException(
-            f"{bc.FAIL}{addon}{bc.ENDC} does not exist on {branch.ref()}"
-        )
-    return True
+def prepare_remote_error_msg(repo_name, remote):
+    return (
+        f"No remote {bc.FAIL}{remote}{bc.END} in the current repository.\n"
+        "To add it:\n"
+        "\t# This mode requires an SSH key in the GitHub account\n"
+        f"\t{bc.DIM}$ git remote add {remote} "
+        f"git@github.com:{remote}/{repo_name}.git{bc.END}\n"
+        "   Or:\n"
+        "\t# This will require to enter user/password each time\n"
+        f"\t{bc.DIM}$ git remote add {remote} "
+        f"https://github.com/{remote}/{repo_name}.git{bc.END}"
+    )
 
 
 if __name__ == "__main__":
     main()
+
+
+@dataclass
+class App:
+    """'oca-port' application centralizing settings and operations.
+
+    Parameters:
+
+        from_branch:
+            the source branch (e.g. '15.0')
+        to_branch:
+            the source branch (e.g. '16.0')
+        addon:
+            the name of the module to process
+        repo_path:
+            local path to the Git repository
+        fork:
+            name of the Git remote used as fork
+        repo_name:
+            name of the repository on the upstream organization (e.g. 'server-tools')
+        user_org:
+            name of the user's GitHub organization where the fork is hosted
+        upstream_org:
+            name of the upstream GitHub organization (default = 'OCA')
+        upstream:
+            name of the Git remote considered as the upstream (default = 'origin')
+        verbose:
+            returns more details to the user
+        non_interactive:
+            flag to not wait for user input and to return a error code to the shell.
+            Returns 1 if something can be ported, 0 otherwise.
+        no_cache:
+            flag to disable the user's cache
+        clear_cache:
+            flag to remove the user's cache once the process is done
+    """
+
+    from_branch: str
+    to_branch: str
+    addon: str
+    repo_path: str
+    fork: str = None
+    repo_name: str = None
+    user_org: str = None
+    upstream_org: str = "OCA"
+    upstream: str = "origin"
+    verbose: bool = False
+    non_interactive: bool = False
+    no_cache: bool = False
+    clear_cache: bool = False
+
+    def __post_init__(self):
+        # Handle with repo_path and repo_name
+        if self.repo_path:
+            self.repo_path = pathlib.Path(self.repo_path)
+        else:
+            raise ValueError("'repo_path' has to be set.")
+        if not self.repo_name:
+            self.repo_name = self.repo_path.name
+        # Handle Git repository
+        self.repo = git.Repo(self.repo_path)
+        if self.repo.is_dirty(untracked_files=True):
+            raise ValueError("changes not committed detected in this repository.")
+        # Handle user's organization and fork
+        if not self.user_org:
+            # Assume that the fork remote has the same name than the user organization
+            self.user_org = self.fork
+        if self.fork:
+            if self.fork not in self.repo.remotes:
+                raise ForkValueError(self.repo_name, self.fork)
+        # Transform branch strings to Branch objects
+        try:
+            self.from_branch = Branch(
+                self.repo, self.from_branch, default_remote=self.upstream
+            )
+            self.to_branch = Branch(
+                self.repo, self.to_branch, default_remote=self.upstream
+            )
+        except ValueError as exc:
+            if exc.args[1] not in self.repo.remotes:
+                raise RemoteBranchValueError(self.repo_name, exc.args[1]) from exc
+        # Fetch branches if they can't be resolved locally
+        # NOTE: required for the storage below to retrieve data
+        remote_branches = self.repo.git.branch("-r").split()
+        if (
+            self.from_branch.remote and self.from_branch.ref() not in remote_branches
+        ) or (self.to_branch.remote and self.to_branch.ref() not in remote_branches):
+            self.fetch_branches()
+        # Initialize storage & cache
+        self.storage = utils.storage.InputStorage(self.to_branch, self.addon)
+        self.cache = utils.cache.UserCacheFactory(self).build()
+
+    def fetch_branches(self):
+        for branch in (self.from_branch, self.to_branch):
+            if not branch.remote:
+                continue
+            remote_url = branch.repo.remotes[branch.remote].url
+            if self.verbose:
+                print(f"Fetch {bc.BOLD}{branch.ref()}{bc.END} from {remote_url}")
+            branch.repo.remotes[branch.remote].fetch(branch.name)
+
+    def _check_addon_exists(self, branch, raise_exc=False):
+        repo = self.repo
+        addon = self.addon
+        branch_addons = [t.path for t in repo.commit(branch.ref()).tree.trees]
+        if addon not in branch_addons:
+            if not raise_exc:
+                return False
+            raise ValueError(
+                f"{bc.FAIL}{addon}{bc.ENDC} does not exist on {branch.ref()}"
+            )
+        return True
+
+    def check_addon_exists_from_branch(self, raise_exc=False):
+        """Check that `addon` exists on the source branch`."""
+        return self._check_addon_exists(self.from_branch, raise_exc=raise_exc)
+
+    def check_addon_exists_to_branch(self, raise_exc=False):
+        """Check that `addon` exists on the target branch`."""
+        return self._check_addon_exists(self.to_branch, raise_exc=raise_exc)
+
+    def run(self):
+        """Run 'oca-port' to migrate an addon or to port its pull requests."""
+        self.fetch_branches()
+        self.check_addon_exists_from_branch(raise_exc=True)
+        # Check if some PRs could be ported
+        if not self.run_port():
+            # If not, migrate the addon
+            self.run_migrate()
+        if self.clear_cache:
+            self.cache.clear()
+
+    def run_port(self):
+        """Port pull requests of an addon (if any)."""
+        # Check if the addon (folder) exists on the target branch
+        #   - if it already exists, check if some PRs could be ported
+        if self.check_addon_exists_to_branch():
+            PortAddonPullRequest(self).run()
+            return True
+        return False
+
+    def run_migrate(self):
+        """Migrate an addon."""
+        MigrateAddon(self).run()
+        return True

--- a/oca_port/__init__.py
+++ b/oca_port/__init__.py
@@ -191,7 +191,8 @@ class App:
             returns more details to the user
         non_interactive:
             flag to not wait for user input and to return a error code to the shell.
-            Returns 1 if something can be ported, 0 otherwise.
+            Returns 100 if an addon could be migrated, 110 if pull requests/commits
+            could be ported, 0 if the history of the addon is the same on both branches.
         no_cache:
             flag to disable the user's cache
         clear_cache:

--- a/oca_port/exceptions.py
+++ b/oca_port/exceptions.py
@@ -1,0 +1,10 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+
+class ForkValueError(ValueError):
+    pass
+
+
+class RemoteBranchValueError(ValueError):
+    pass

--- a/oca_port/migrate_addon.py
+++ b/oca_port/migrate_addon.py
@@ -9,7 +9,7 @@ import click
 
 from .port_addon_pr import PortAddonPullRequest
 from .utils import git as g
-from .utils.misc import bcolors as bc
+from .utils.misc import Output, bcolors as bc
 
 MIG_BRANCH_NAME = "{branch}-mig-{addon}"
 MIG_MERGE_COMMITS_URL = (
@@ -58,7 +58,7 @@ BLACKLIST_TIPS = "\n".join(
 )
 
 
-class MigrateAddon:
+class MigrateAddon(Output):
     def __init__(self, app):
         self.app = app
         self.mig_branch = g.Branch(
@@ -71,7 +71,7 @@ class MigrateAddon:
     def run(self):
         blacklisted = self.app.storage.is_addon_blacklisted()
         if blacklisted:
-            print(
+            self._print(
                 f"{bc.DIM}Migration of {bc.BOLD}{self.app.addon}{bc.END} "
                 f"{bc.DIM}to {self.app.to_branch.name} "
                 f"blacklisted ({blacklisted}){bc.ENDD}"

--- a/oca_port/migrate_addon.py
+++ b/oca_port/migrate_addon.py
@@ -59,134 +59,101 @@ BLACKLIST_TIPS = "\n".join(
 
 
 class MigrateAddon:
-    def __init__(
-        self,
-        repo,
-        upstream_org,
-        repo_name,
-        from_branch,
-        to_branch,
-        fork,
-        user_org,
-        addon,
-        storage,
-        cache=None,
-        verbose=False,
-        non_interactive=False,
-    ):
-        self.repo = repo
-        self.upstream_org = upstream_org
-        self.repo_name = repo_name
-        self.from_branch = from_branch
-        self.to_branch = to_branch
-        self.fork = fork
-        self.user_org = user_org
-        self.addon = addon
-        self.storage = storage
-        self.cache = cache
+    def __init__(self, app):
+        self.app = app
         self.mig_branch = g.Branch(
-            repo, MIG_BRANCH_NAME.format(branch=to_branch.name[:4], addon=addon)
+            self.app.repo,
+            MIG_BRANCH_NAME.format(
+                branch=self.app.to_branch.name[:4], addon=self.app.addon
+            ),
         )
-        self.verbose = verbose
-        self.non_interactive = non_interactive
 
     def run(self):
-        blacklisted = self.storage.is_addon_blacklisted()
+        blacklisted = self.app.storage.is_addon_blacklisted()
         if blacklisted:
             print(
-                f"{bc.DIM}Migration of {bc.BOLD}{self.addon}{bc.END} "
-                f"{bc.DIM}to {self.to_branch.name} "
+                f"{bc.DIM}Migration of {bc.BOLD}{self.app.addon}{bc.END} "
+                f"{bc.DIM}to {self.app.to_branch.name} "
                 f"blacklisted ({blacklisted}){bc.ENDD}"
             )
             return
-        if self.non_interactive:
+        if self.app.non_interactive:
             # Exit with an error code if the addon is eligible for a migration
             raise SystemExit(1)
         confirm = (
-            f"Migrate {bc.BOLD}{self.addon}{bc.END} "
-            f"from {bc.BOLD}{self.from_branch.name}{bc.END} "
-            f"to {bc.BOLD}{self.to_branch.name}{bc.END}?"
+            f"Migrate {bc.BOLD}{self.app.addon}{bc.END} "
+            f"from {bc.BOLD}{self.app.from_branch.name}{bc.END} "
+            f"to {bc.BOLD}{self.app.to_branch.name}{bc.END}?"
         )
         if not click.confirm(confirm):
-            self.storage.blacklist_addon(confirm=True)
-            if not self.storage.dirty:
+            self.app.storage.blacklist_addon(confirm=True)
+            if not self.app.storage.dirty:
                 return
         # Check if a migration PR already exists
         # TODO
-        if not self.fork:
+        if not self.app.fork:
             raise click.UsageError("Please set the '--fork' option")
-        if self.repo.untracked_files:
+        if self.app.repo.untracked_files:
             raise click.ClickException("Untracked files detected, abort")
         self._checkout_base_branch()
         if self._create_mig_branch():
             # Case where the addon shouldn't be ported (blacklisted)
-            if self.storage.dirty:
-                self.storage.commit()
+            if self.app.storage.dirty:
+                self.app.storage.commit()
                 self._print_tips(blacklisted=True)
                 return
             with tempfile.TemporaryDirectory() as patches_dir:
                 self._generate_patches(patches_dir)
                 self._apply_patches(patches_dir)
-            g.run_pre_commit(self.repo, self.addon)
+            g.run_pre_commit(self.app.repo, self.app.addon)
         # Check if the addon has commits that update neighboring addons to
         # make it work properly
-        PortAddonPullRequest(
-            self.repo,
-            self.upstream_org,
-            self.repo_name,
-            self.from_branch,
-            self.mig_branch,
-            self.fork,
-            self.user_org,
-            self.addon,
-            self.storage,
-            self.cache,
-            self.verbose,
-            create_branch=False,
-            push_branch=False,
-        ).run()
+        PortAddonPullRequest(self.app, create_branch=False, push_branch=False).run()
         self._print_tips()
 
     def _checkout_base_branch(self):
         # Ensure to not start to work from a working branch
-        if self.to_branch.name in self.repo.heads:
-            self.repo.heads[self.to_branch.name].checkout()
+        if self.app.to_branch.name in self.app.repo.heads:
+            self.app.repo.heads[self.app.to_branch.name].checkout()
         else:
-            self.repo.git.checkout(
-                "--no-track", "-b", self.to_branch.name, self.to_branch.ref()
+            self.app.repo.git.checkout(
+                "--no-track",
+                "-b",
+                self.app.to_branch.name,
+                self.app.to_branch.ref(),
             )
 
     def _create_mig_branch(self):
         create_branch = True
-        if self.mig_branch.name in self.repo.heads:
+        if self.mig_branch.name in self.app.repo.heads:
             confirm = (
                 f"Branch {bc.BOLD}{self.mig_branch.name}{bc.END} already exists, "
                 "recreate it?\n(⚠️  you will lose the existing branch)"
             )
             if click.confirm(confirm):
-                self.repo.delete_head(self.mig_branch.name, "-f")
+                self.app.repo.delete_head(self.mig_branch.name, "-f")
             else:
                 create_branch = False
         if create_branch:
             # Create branch
             print(
                 f"\tCreate branch {bc.BOLD}{self.mig_branch.name}{bc.END} "
-                f"from {self.to_branch.ref()}..."
+                f"from {self.app.to_branch.ref()}..."
             )
-            self.repo.git.checkout(
-                "--no-track", "-b", self.mig_branch.name, self.to_branch.ref()
+            self.app.repo.git.checkout(
+                "--no-track", "-b", self.mig_branch.name, self.app.to_branch.ref()
             )
         return create_branch
 
     def _generate_patches(self, patches_dir):
         print("\tGenerate patches...")
-        self.repo.git.format_patch(
+        self.app.repo.git.format_patch(
             "--keep-subject",
             "-o",
             patches_dir,
-            f"{self.to_branch.ref()}..{self.from_branch.ref()}",
+            f"{self.app.to_branch.ref()}..{self.app.from_branch.ref()}",
             "--",
-            self.addon,
+            self.app.addon,
         )
 
     def _apply_patches(self, patches_dir):
@@ -195,41 +162,43 @@ class MigrateAddon:
         ]
         # Apply patches with git-am
         print(f"\tApply {len(patches)} patches...")
-        self.repo.git.am("-3", "--keep", *patches)
+        self.app.repo.git.am("-3", "--keep", *patches)
         print(
-            f"\t\tCommits history of {bc.BOLD}{self.addon}{bc.END} "
+            f"\t\tCommits history of {bc.BOLD}{self.app.addon}{bc.END} "
             f"has been migrated."
         )
 
     def _print_tips(self, blacklisted=False):
-        mig_tasks_url = MIG_TASKS_URL.format(branch=self.to_branch.name)
+        mig_tasks_url = MIG_TASKS_URL.format(branch=self.app.to_branch.name)
         pr_title_encoded = urllib.parse.quote(
-            MIG_NEW_PR_TITLE.format(to_branch=self.to_branch.name[:4], addon=self.addon)
+            MIG_NEW_PR_TITLE.format(
+                to_branch=self.app.to_branch.name[:4], addon=self.app.addon
+            )
         )
         new_pr_url = MIG_NEW_PR_URL.format(
-            upstream_org=self.upstream_org,
-            repo_name=self.repo_name,
-            to_branch=self.to_branch.name,
-            user_org=self.user_org,
+            upstream_org=self.app.upstream_org,
+            repo_name=self.app.repo_name,
+            to_branch=self.app.to_branch.name,
+            user_org=self.app.user_org,
             mig_branch=self.mig_branch.name,
             title=pr_title_encoded,
         )
         if blacklisted:
             tips = BLACKLIST_TIPS.format(
-                upstream_org=self.upstream_org,
-                repo_name=self.repo_name,
-                fork=self.fork,
+                upstream_org=self.app.upstream_org,
+                repo_name=self.app.repo_name,
+                fork=self.app.fork,
                 mig_branch=self.mig_branch.name,
                 new_pr_url=new_pr_url,
             )
             print(tips)
             return
         tips = MIG_TIPS.format(
-            upstream_org=self.upstream_org,
-            repo_name=self.repo_name,
-            addon=self.addon,
-            to_branch=self.to_branch.name,
-            fork=self.fork,
+            upstream_org=self.app.upstream_org,
+            repo_name=self.app.repo_name,
+            addon=self.app.addon,
+            to_branch=self.app.to_branch.name,
+            fork=self.app.fork,
             mig_branch=self.mig_branch.name,
             mig_tasks_url=mig_tasks_url,
             new_pr_url=new_pr_url,

--- a/oca_port/migrate_addon.py
+++ b/oca_port/migrate_addon.py
@@ -79,7 +79,9 @@ class MigrateAddon:
             return
         if self.app.non_interactive:
             # Exit with an error code if the addon is eligible for a migration
-            raise SystemExit(1)
+            # User-defined exit codes should be defined between 64 and 113.
+            # Allocate 105 for 'PortAddonPullRequest'.
+            raise SystemExit(100)
         confirm = (
             f"Migrate {bc.BOLD}{self.app.addon}{bc.END} "
             f"from {bc.BOLD}{self.app.from_branch.name}{bc.END} "

--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -54,68 +54,32 @@ def path_to_skip(commit_path):
 
 
 class PortAddonPullRequest:
-    def __init__(
-        self,
-        repo,
-        upstream_org,
-        repo_name,
-        from_branch,
-        to_branch,
-        fork,
-        user_org,
-        addon,
-        storage,
-        cache=None,
-        verbose=False,
-        non_interactive=False,
-        create_branch=True,
-        push_branch=True,
-    ):
-        """Port pull requests of `addon`."""
-        self.repo = repo
-        self.upstream_org = upstream_org
-        self.repo_name = repo_name
-        self.from_branch = from_branch
-        self.to_branch = to_branch
-        self.fork = fork
-        self.user_org = user_org
-        self.addon = addon
-        self.storage = storage
-        self.cache = cache
-        self.verbose = verbose
-        self.non_interactive = non_interactive
+    def __init__(self, app, create_branch=True, push_branch=True):
+        """Port pull requests of an addon."""
+        self.app = app
         self.create_branch = create_branch
         self.push_branch = push_branch
 
     def run(self):
         print(
-            f"{bc.BOLD}{self.addon}{bc.END} already exists "
-            f"on {bc.BOLD}{self.to_branch.name}{bc.END}, "
+            f"{bc.BOLD}{self.app.addon}{bc.END} already exists "
+            f"on {bc.BOLD}{self.app.to_branch.name}{bc.END}, "
             "checking PRs to port..."
         )
-        branches_diff = BranchesDiff(
-            self.repo,
-            self.upstream_org,
-            self.repo_name,
-            self.addon,
-            self.from_branch,
-            self.to_branch,
-            self.storage,
-            self.cache,
-        )
-        branches_diff.print_diff(self.verbose)
-        if self.non_interactive:
+        branches_diff = BranchesDiff(self.app)
+        branches_diff.print_diff(self.app.verbose)
+        if self.app.non_interactive:
             if branches_diff.commits_diff:
                 # Exit with an error code if commits are eligible for (back)porting
                 raise SystemExit(1)
             return
-        if self.fork:
+        if self.app.fork:
             print()
             self._port_pull_requests(branches_diff)
 
     def _port_pull_requests(self, branches_diff):
         """Open new Pull Requests (if it doesn't exist) on the GitHub repository."""
-        base_ref = branches_diff.to_branch  # e.g. 'origin/14.0'
+        base_ref = branches_diff.app.to_branch  # e.g. 'origin/14.0'
         previous_pr = previous_pr_branch = None
         processed_prs = []
         last_pr = (
@@ -124,7 +88,7 @@ class PortAddonPullRequest:
             else None
         )
         for pr, commits in branches_diff.commits_diff.items():
-            current_commit = self.repo.commit(self.to_branch.ref())
+            current_commit = self.app.repo.commit(self.app.to_branch.ref())
             pr_branch, based_on_previous = self._port_pull_request_commits(
                 pr,
                 commits,
@@ -135,15 +99,15 @@ class PortAddonPullRequest:
             if pr_branch:
                 # Check if commits have been ported.
                 # If none has been ported, blacklist automatically the current PR.
-                if self.repo.commit(pr_branch.ref()) == current_commit:
+                if self.app.repo.commit(pr_branch.ref()) == current_commit:
                     print("\tℹ️  Nothing has been ported, skipping")
-                    self.storage.blacklist_pr(
+                    self.app.storage.blacklist_pr(
                         pr.number,
                         confirm=True,
                         reason=f"(auto) Nothing to port from PR #{pr.number}",
                     )
-                    if self.storage.dirty:
-                        self.storage.commit()
+                    if self.app.storage.dirty:
+                        self.app.storage.commit()
                     msg = (
                         f"\t{bc.DIM}PR #{pr.number} has been"
                         if pr.number
@@ -189,30 +153,33 @@ class PortAddonPullRequest:
             print(f"- {bc.BOLD}{bc.OKCYAN}Port commits w/o PR{bc.END}...")
         based_on_previous = False
         # Ensure to not start to work from a working branch
-        if self.to_branch.name in self.repo.heads:
-            self.repo.heads[self.to_branch.name].checkout()
+        if self.app.to_branch.name in self.app.repo.heads:
+            self.app.repo.heads[self.app.to_branch.name].checkout()
         else:
-            self.repo.git.checkout(
-                "--no-track", "-b", self.to_branch.name, self.to_branch.ref()
+            self.app.repo.git.checkout(
+                "--no-track",
+                "-b",
+                self.app.to_branch.name,
+                self.app.to_branch.ref(),
             )
         # Ask the user if he wants to port the PR (or orphaned commits)
         if not click.confirm("\tPort it?" if pr.number else "\tPort them?"):
-            self.storage.blacklist_pr(pr.number, confirm=True)
-            if not self.storage.dirty:
+            self.app.storage.blacklist_pr(pr.number, confirm=True)
+            if not self.app.storage.dirty:
                 return None, based_on_previous
         # Create a local branch based on upstream
         if self.create_branch:
             branch_name = PR_BRANCH_NAME.format(
-                from_branch=self.from_branch.name,
-                to_branch=self.to_branch.name,
+                from_branch=self.app.from_branch.name,
+                to_branch=self.app.to_branch.name,
                 pr_number=pr.number,
             )
-            if branch_name in self.repo.heads:
+            if branch_name in self.app.repo.heads:
                 # If the local branch already exists, ask the user if he wants
                 # to recreate it + check if this existing branch is based on
                 # the previous PR branch
                 if previous_pr_branch:
-                    based_on_previous = self.repo.is_ancestor(
+                    based_on_previous = self.app.repo.is_ancestor(
                         previous_pr_branch.name, branch_name
                     )
                 confirm = (
@@ -220,8 +187,8 @@ class PortAddonPullRequest:
                     "recreate it?\n\t(⚠️  you will lose the existing branch)"
                 )
                 if not click.confirm(confirm):
-                    return g.Branch(self.repo, branch_name), based_on_previous
-                self.repo.delete_head(branch_name, "-f")
+                    return g.Branch(self.app.repo, branch_name), based_on_previous
+                self.app.repo.delete_head(branch_name, "-f")
             if previous_pr and click.confirm(
                 f"\tUse the previous {bc.BOLD}PR #{previous_pr.number}{bc.END} "
                 "branch as base?"
@@ -234,13 +201,13 @@ class PortAddonPullRequest:
             print(
                 f"\tCreate branch {bc.BOLD}{branch_name}{bc.END} from {base_ref.ref()}..."
             )
-            self.repo.git.checkout("--no-track", "-b", branch_name, base_ref.ref())
+            self.app.repo.git.checkout("--no-track", "-b", branch_name, base_ref.ref())
         else:
-            branch_name = self.to_branch.name
+            branch_name = self.app.to_branch.name
         # If the PR has been blacklisted we need to commit this information
-        if self.storage.dirty:
-            self.storage.commit()
-            return g.Branch(self.repo, branch_name), based_on_previous
+        if self.app.storage.dirty:
+            self.app.storage.commit()
+            return g.Branch(self.app.repo, branch_name), based_on_previous
 
         # Cherry-pick commits of the source PR
         for commit in commits:
@@ -265,7 +232,7 @@ class PortAddonPullRequest:
                 continue
             try:
                 patches_dir = tempfile.mkdtemp()
-                self.repo.git.format_patch(
+                self.app.repo.git.format_patch(
                     "--keep-subject",
                     "-o",
                     patches_dir,
@@ -278,7 +245,7 @@ class PortAddonPullRequest:
                     os.path.join(patches_dir, f)
                     for f in sorted(os.listdir(patches_dir))
                 ]
-                self.repo.git.am("-3", "--keep", *patches)
+                self.app.repo.git.am("-3", "--keep", *patches)
                 shutil.rmtree(patches_dir)
             except git.exc.GitCommandError as exc:
                 print(f"{bc.FAIL}ERROR:{bc.ENDC}\n{exc}\n")
@@ -287,9 +254,9 @@ class PortAddonPullRequest:
                     "⚠️  A conflict occurs, please resolve it and "
                     "confirm to continue the process (y) or skip this commit (N)."
                 ):
-                    self.repo.git.am("--abort")
+                    self.app.repo.git.am("--abort")
                     continue
-        return g.Branch(self.repo, branch_name), based_on_previous
+        return g.Branch(self.app.repo, branch_name), based_on_previous
 
     @staticmethod
     def _skip_diff(commit, diff):
@@ -336,46 +303,48 @@ class PortAddonPullRequest:
         """Force push the local branch to remote fork."""
         confirm = (
             f"\tPush branch '{bc.BOLD}{branch.name}{bc.END}' "
-            f"to remote '{bc.BOLD}{self.fork}{bc.END}'?"
+            f"to remote '{bc.BOLD}{self.app.fork}{bc.END}'?"
         )
         if click.confirm(confirm):
-            branch.repo.git.push(self.fork, branch.name, "--force-with-lease")
-            branch.remote = self.fork
+            branch.repo.git.push(self.app.fork, branch.name, "--force-with-lease")
+            branch.remote = self.app.fork
             return True
 
     def _prepare_pull_request_data(self, processed_prs, pr_branch):
         if len(processed_prs) > 1:
             title = (
-                f"[{self.to_branch.name}][FW] {self.addon}: multiple ports "
-                f"from {self.from_branch.name}"
+                f"[{self.app.to_branch.name}][FW] {self.app.addon}: multiple ports "
+                f"from {self.app.from_branch.name}"
             )
             lines = [f"- #{pr.number}" for pr in processed_prs]
             body = "\n".join(
                 [
-                    f"Port of the following PRs from {self.from_branch.name} "
-                    f"to {self.to_branch.name}:"
+                    f"Port of the following PRs from {self.app.from_branch.name} "
+                    f"to {self.app.to_branch.name}:"
                 ]
                 + lines
             )
         else:
             pr = processed_prs[0]
-            title = f"[{self.to_branch.name}][FW] {pr.title}"
+            title = f"[{self.app.to_branch.name}][FW] {pr.title}"
             body = (
-                f"Port of #{pr.number} from {self.from_branch.name} "
-                f"to {self.to_branch.name}."
+                f"Port of #{pr.number} from {self.app.from_branch.name} "
+                f"to {self.app.to_branch.name}."
             )
         return {
             "draft": True,
             "title": title,
-            "head": f"{self.user_org}:{pr_branch.name}",
-            "base": self.to_branch.name,
+            "head": f"{self.app.user_org}:{pr_branch.name}",
+            "base": self.app.to_branch.name,
             "body": body,
         }
 
     def _search_pull_request(self, base_branch, title):
         params = {
             "q": (
-                f"is:pr repo:{self.upstream_org}/{self.repo_name} base:{base_branch} "
+                f"is:pr "
+                f"repo:{self.app.upstream_org}/{self.app.repo_name} "
+                f"base:{base_branch} "
                 f"state:open {title} in:title"
             ),
         }
@@ -393,11 +362,11 @@ class PortAddonPullRequest:
             )
         if click.confirm(
             f"\tCreate a draft PR from '{bc.BOLD}{pr_branch.name}{bc.END}' "
-            f"to '{bc.BOLD}{self.to_branch.name}{bc.END}' "
-            f"against {bc.BOLD}{self.upstream_org}/{self.repo_name}{bc.END}?"
+            f"to '{bc.BOLD}{self.app.to_branch.name}{bc.END}' "
+            f"against {bc.BOLD}{self.app.upstream_org}/{self.app.repo_name}{bc.END}?"
         ):
             response = github.request(
-                f"repos/{self.upstream_org}/{self.repo_name}/pulls",
+                f"repos/{self.app.upstream_org}/{self.app.repo_name}/pulls",
                 method="post",
                 json=pr_data,
             )
@@ -411,34 +380,21 @@ class PortAddonPullRequest:
 class BranchesDiff:
     """Helper to compare easily commits (and related PRs) between two branches."""
 
-    def __init__(
-        self,
-        repo,
-        upstream_org,
-        repo_name,
-        path,
-        from_branch,
-        to_branch,
-        storage,
-        cache,
-    ):
-        self.repo = repo
-        self.upstream_org = upstream_org
-        self.repo_name = repo_name
-        self.path = path
-        self.from_branch, self.to_branch = from_branch, to_branch
-        self.storage = storage
-        self.cache = cache
+    def __init__(self, app):
+        self.app = app
+        self.path = self.app.addon
         self.from_branch_path_commits, _ = self._get_branch_commits(
-            self.from_branch.ref(), path
+            self.app.from_branch.ref(), self.path
         )
         self.from_branch_all_commits, _ = self._get_branch_commits(
-            self.from_branch.ref()
+            self.app.from_branch.ref()
         )
         self.to_branch_path_commits, _ = self._get_branch_commits(
-            self.to_branch.ref(), self.path
+            self.app.to_branch.ref(), self.path
         )
-        self.to_branch_all_commits, _ = self._get_branch_commits(self.to_branch.ref())
+        self.to_branch_all_commits, _ = self._get_branch_commits(
+            self.app.to_branch.ref()
+        )
         self.commits_diff = self.get_commits_diff()
 
     def _get_branch_commits(self, branch, path="."):
@@ -452,11 +408,11 @@ class BranchesDiff:
             - a list of Commit objects `[Commit, ...]`
             - a dict of Commits objects grouped by SHA `{SHA: Commit, ...}`
         """
-        commits = self.repo.iter_commits(branch, paths=path)
+        commits = self.app.repo.iter_commits(branch, paths=path)
         commits_list = []
         commits_by_sha = {}
         for commit in commits:
-            if self.cache.is_commit_ported(commit.hexsha):
+            if self.app.cache.is_commit_ported(commit.hexsha):
                 continue
             com = g.Commit(commit)
             if self._skip_commit(com):
@@ -523,14 +479,14 @@ class BranchesDiff:
                 f"{bc.BOLD}{bc.OKBLUE}{i} pull request(s){bc.END} "
                 f"and {bc.BOLD}{bc.OKBLUE}{nb_commits} commit(s) w/o "
                 f"PR{bc.END} related to '{bc.OKBLUE}{self.path}"
-                f"{bc.ENDC}' to port from {self.from_branch.ref()} "
-                f"to {self.to_branch.ref()}"
+                f"{bc.ENDC}' to port from {self.app.from_branch.ref()} "
+                f"to {self.app.to_branch.ref()}"
             )
         else:
             message = (
                 f"{bc.BOLD}{bc.OKBLUE}{i} pull request(s){bc.END} "
                 f"related to '{bc.OKBLUE}{self.path}{bc.ENDC}' to port from "
-                f"{self.from_branch.ref()} to {self.to_branch.ref()}"
+                f"{self.app.from_branch.ref()} to {self.app.to_branch.ref()}"
             )
         lines_to_print.insert(0, message)
         print("\n".join(lines_to_print))
@@ -544,14 +500,14 @@ class BranchesDiff:
         commits_by_pr = defaultdict(list)
         for commit in self.from_branch_path_commits:
             if commit in self.to_branch_all_commits:
-                self.cache.mark_commit_as_ported(commit.hexsha)
+                self.app.cache.mark_commit_as_ported(commit.hexsha)
                 continue
             # Get related Pull Request if any
             pr = self._get_original_pr(commit)
             if pr:
                 for pr_commit_sha in pr.commits:
                     try:
-                        raw_commit = self.repo.commit(pr_commit_sha)
+                        raw_commit = self.app.repo.commit(pr_commit_sha)
                     except ValueError:
                         # Ignore commits referenced by a PR but not present
                         # in the stable branches
@@ -622,7 +578,7 @@ class BranchesDiff:
         # Do not return blacklisted PR.
         sorted_commits_by_pr = {}
         for pr in sorted(commits_by_pr, key=lambda pr: pr.merged_at or ""):
-            blacklisted = self.storage.is_pr_blacklisted(pr.number)
+            blacklisted = self.app.storage.is_pr_blacklisted(pr.number)
             if blacklisted:
                 msg = (
                     f"{bc.DIM}PR #{pr.number}" if pr.number else "Orphaned commits"
@@ -635,14 +591,17 @@ class BranchesDiff:
     def _get_original_pr(self, commit: g.Commit):
         """Return the original PR of a given commit."""
         # Try to get the data from the user's cache first
-        data = self.cache.get_pr_from_commit(commit.hexsha)
+        data = self.app.cache.get_pr_from_commit(commit.hexsha)
         if data:
             return g.PullRequest(**data)
         # Request GitHub to get them
-        if not any("github.com" in remote.url for remote in self.repo.remotes):
+        if not any("github.com" in remote.url for remote in self.app.repo.remotes):
             return
         raw_data = github.get_original_pr(
-            self.upstream_org, self.repo_name, self.from_branch.name, commit.hexsha
+            self.app.upstream_org,
+            self.app.repo_name,
+            self.app.from_branch.name,
+            commit.hexsha,
         )
         if raw_data:
             # Get all commits of the PR as they could update others addons
@@ -650,7 +609,7 @@ class BranchesDiff:
             # NOTE: commits fetched from PR are already in the right order
             pr_number = raw_data["number"]
             pr_commits_data = github.request(
-                f"repos/{self.upstream_org}/{self.repo_name}"
+                f"repos/{self.app.upstream_org}/{self.app.repo_name}"
                 f"/pulls/{pr_number}/commits?per_page=100"
             )
             pr_commits = [pr["sha"] for pr in pr_commits_data]
@@ -663,5 +622,5 @@ class BranchesDiff:
                 "merged_at": raw_data["merged_at"],
                 "commits": pr_commits,
             }
-            self.cache.store_commit_pr(commit.hexsha, data)
+            self.app.cache.store_commit_pr(commit.hexsha, data)
             return g.PullRequest(**data)

--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -59,6 +59,7 @@ class PortAddonPullRequest(Output):
         self.app = app
         self.create_branch = create_branch
         self.push_branch = push_branch
+        self._results = {"process": "port_commits", "results": {}}
 
     def run(self):
         self._print(
@@ -70,14 +71,24 @@ class PortAddonPullRequest(Output):
         branches_diff.print_diff(self.app.verbose)
         if self.app.non_interactive:
             if branches_diff.commits_diff:
-                # Exit with an error code if commits are eligible for (back)porting
-                # User-defined exit codes should be defined between 64 and 113.
-                # Allocate 110 for 'PortAddonPullRequest'.
-                raise SystemExit(110)
-            return
+                # If an output is defined we return the result in the expected format
+                if self.app.output:
+                    self._results["results"] = branches_diff.serialized_diff
+                    return self._render_output(self.app.output, self._results)
+                if self.app.cli:
+                    # Exit with an error code if commits are eligible for (back)porting
+                    # User-defined exit codes should be defined between 64 and 113.
+                    # Allocate 110 for 'PortAddonPullRequest'.
+                    raise SystemExit(110)
+                return True
+            if self.app.output:
+                # Nothing to port -> return an empty output
+                return self._render_output(self.app.output, {})
+            return False
         if self.app.fork:
             self._print()
             self._port_pull_requests(branches_diff)
+        return True
 
     def _port_pull_requests(self, branches_diff):
         """Open new Pull Requests (if it doesn't exist) on the GitHub repository."""
@@ -399,6 +410,14 @@ class BranchesDiff(Output):
             self.app.to_branch.ref()
         )
         self.commits_diff = self.get_commits_diff()
+        self.serialized_diff = self._serialize_diff(self.commits_diff)
+
+    def _serialize_diff(self, commits_diff):
+        data = {}
+        for pr, commits in commits_diff.items():
+            data[pr.number] = pr.to_dict()
+            data[pr.number]["missing_commits"] = [commit.hexsha for commit in commits]
+        return data
 
     def _get_branch_commits(self, branch, path="."):
         """Get commits from the local repository for the given `branch`.

--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -71,7 +71,9 @@ class PortAddonPullRequest:
         if self.app.non_interactive:
             if branches_diff.commits_diff:
                 # Exit with an error code if commits are eligible for (back)porting
-                raise SystemExit(1)
+                # User-defined exit codes should be defined between 64 and 113.
+                # Allocate 110 for 'PortAddonPullRequest'.
+                raise SystemExit(110)
             return
         if self.app.fork:
             print()

--- a/oca_port/utils/git.py
+++ b/oca_port/utils/git.py
@@ -222,6 +222,21 @@ class PullRequest(abc.Hashable):
     def paths_not_ported(self):
         return list(self.paths - self.ported_paths)
 
+    def to_dict(self, number=False, body=False, commits=False):
+        data = {
+            "url": self.url,
+            "author": self.author,
+            "title": self.title,
+            "merged_at": str(self.merged_at),
+        }
+        if number:
+            data["number"] = self.number
+        if body:
+            data["body"] = self.body
+        if commits:
+            data["commits"] = [c.hexsha for c in self.commits]
+        return data
+
 
 def run_pre_commit(repo, addon, commit=True, hook=None):
     # Run pre-commit

--- a/oca_port/utils/git.py
+++ b/oca_port/utils/git.py
@@ -189,7 +189,7 @@ class PullRequest(abc.Hashable):
         author,
         title,
         body,
-        merged_at,
+        merged_at=None,
         commits=None,
         paths=None,
         ported_paths=None,
@@ -227,7 +227,7 @@ class PullRequest(abc.Hashable):
             "url": self.url,
             "author": self.author,
             "title": self.title,
-            "merged_at": str(self.merged_at),
+            "merged_at": str(self.merged_at or ""),
         }
         if number:
             data["number"] = self.number

--- a/oca_port/utils/misc.py
+++ b/oca_port/utils/misc.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Camptocamp SA
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
 
+import json
 import os
 import re
 from collections import defaultdict
@@ -51,5 +52,13 @@ class Output:
         app = self
         if hasattr(self, "app"):
             app = self.app
-        if app.cli:
+        if app.cli and not app.output:
             print(*args, **kwargs)
+
+    def _render_output(self, output, data):
+        """Render the data with the expected format."""
+        return getattr(self, f"_render_output_{output}")(data)
+
+    def _render_output_json(self, data):
+        """Render the data as JSON."""
+        return json.dumps(data)

--- a/oca_port/utils/misc.py
+++ b/oca_port/utils/misc.py
@@ -41,3 +41,15 @@ def defaultdict_from_dict(d):
     ni = nd()
     ni.update(d)
     return ni
+
+
+class Output:
+    """Mixin to handle the output of oca-port."""
+
+    def _print(self, *args, **kwargs):
+        """Like built-in 'print' method but check if oca-port is used in CLI."""
+        app = self
+        if hasattr(self, "app"):
+            app = self.app
+        if app.cli:
+            print(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ repository = "https://github.com/OCA/oca-port"
 [project.scripts]
 oca-port = "oca_port:main"
 
+[project.optional-dependencies]
+test = [
+  "pytest",
+]
+
 [build-system]
 requires = ["setuptools>=64", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,81 @@
+import os
+import pathlib
+import shutil
+import tempfile
+import time
+import unittest
+
+import git
+
+
+class CommonCase(unittest.TestCase):
+
+    _settings = {
+        "branch1": "15.0",
+        "branch2": "16.0",
+        "branch3": "17.0",
+        "addon": "my_module",
+        "upstream_org": "OCA",
+        "upstream": None,  # We're testing locally without any remote
+        "user_org": "OCA-test",
+        "no_cache": True,
+    }
+
+    def setUp(self):
+        # Create a temporary Git repository
+        self.repo_path = self._create_tmp_git_repository()
+        self.module_path = os.path.join(self.repo_path, self._settings["addon"])
+        self.manifest_path = os.path.join(self.module_path, "__manifest__.py")
+        self._fill_git_repository()
+
+    def _create_tmp_git_repository(self):
+        """Create a temporary Git repository to run tests."""
+        repo_path = tempfile.mkdtemp()
+        git.Repo.init(repo_path)
+        return repo_path
+
+    def _fill_git_repository(self):
+        """Create branches with some content in the Git repository."""
+        repo = git.Repo(self.repo_path)
+        tpl_manifest_path = os.path.join(
+            pathlib.Path(__file__).parent.resolve(),
+            "data",
+            "manifest.py",
+        )
+        with open(tpl_manifest_path) as tpl_manifest:
+            tpl_manifest_lines = tpl_manifest.readlines()
+        # Commit a file in '15.0'
+        repo.git.checkout("--orphan", self._settings["branch1"])
+        os.makedirs(self.module_path, exist_ok=True)
+        with open(self.manifest_path, "w") as manifest:
+            manifest.writelines(tpl_manifest_lines)
+        repo.index.add(self.manifest_path)
+        commit = repo.index.commit(f"[ADD] {self._settings['addon']}")
+        # Port the commit from 'branch1' to 'branch2'
+        repo.git.checkout("--orphan", self._settings["branch2"])
+        repo.git.reset("--hard")
+        # FIXME without a delay, both branches are targeting the same commit,
+        # no idea why.
+        time.sleep(1)
+        repo.git.cherry_pick(commit.hexsha)
+        # Create an empty 'branch3'
+        repo.git.checkout("--orphan", self._settings["branch3"])
+        repo.git.reset("--hard")
+        repo.git.commit("-m", "Init", "--allow-empty")
+
+    def _commit_change_on_branch(self, branch):
+        """Commit a change that can be ported to another branch."""
+        repo = git.Repo(self.repo_path)
+        repo.git.checkout(branch)
+        # Do some changes and commit
+        with open(self.manifest_path, "r+") as manifest:
+            content = manifest.read()
+            content = content.replace('"base"', '"sale"')
+            manifest.seek(0)
+            manifest.write(content)
+        repo.index.add(self.manifest_path)
+        repo.index.commit(f"[FIX] {self._settings['addon']}: fix dependency")
+
+    def tearDown(self):
+        # Clean up the Git repository
+        shutil.rmtree(self.repo_path)

--- a/tests/common.py
+++ b/tests/common.py
@@ -74,7 +74,8 @@ class CommonCase(unittest.TestCase):
             manifest.seek(0)
             manifest.write(content)
         repo.index.add(self.manifest_path)
-        repo.index.commit(f"[FIX] {self._settings['addon']}: fix dependency")
+        commit = repo.index.commit(f"[FIX] {self._settings['addon']}: fix dependency")
+        return commit.hexsha
 
     def tearDown(self):
         # Clean up the Git repository

--- a/tests/common.py
+++ b/tests/common.py
@@ -15,7 +15,7 @@ class CommonCase(unittest.TestCase):
         "branch2": "16.0",
         "branch3": "17.0",
         "addon": "my_module",
-        "upstream_org": "OCA",
+        "upstream_org": None,
         "upstream": None,  # We're testing locally without any remote
         "user_org": "OCA-test",
         "no_cache": True,

--- a/tests/data/manifest.py
+++ b/tests/data/manifest.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+{
+    "name": "Test",
+    "version": "1.0.0",
+    "category": "Test Module",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/oca-port",
+    "license": "AGPL-3",
+    "depends": ["base"],
+    "data": [],
+    "demo": [],
+    "installable": True,
+}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,7 @@ from . import common
 
 
 class TestApp(common.CommonCase):
-    def _create_app(self, from_branch, to_branch):
+    def _create_app(self, from_branch, to_branch, **kwargs):
         params = {
             "from_branch": from_branch,
             "to_branch": to_branch,
@@ -18,6 +18,7 @@ class TestApp(common.CommonCase):
             "user_org": self._settings["user_org"],
             "no_cache": self._settings["no_cache"],
         }
+        params.update(kwargs)
         # NOTE: app will run in non-interactive mode
         return oca_port.App(**params)
 
@@ -45,3 +46,70 @@ class TestApp(common.CommonCase):
         except SystemExit as exc:
             # exit code 100 means the module could be migrated
             self.assertEqual(exc.args[0], 100)
+
+    def test_app_commit_to_port_non_interactive(self):
+        app = self._create_app(
+            self._settings["branch1"],
+            self._settings["branch2"],
+            non_interactive=True,
+        )
+        self._commit_change_on_branch(self._settings["branch1"])
+        result = app.run()
+        self.assertTrue(result)
+        self.assertIsInstance(result, bool)
+
+    def test_app_module_to_migrate_non_interactive(self):
+        app = self._create_app(
+            self._settings["branch2"],
+            self._settings["branch3"],
+            non_interactive=True,
+        )
+        result = app.run()
+        self.assertTrue(result)
+        self.assertIsInstance(result, bool)
+
+    def test_app_wrong_output(self):
+        with self.assertRaisesRegex(ValueError, "Supported outputs are"):
+            self._create_app(
+                self._settings["branch2"],
+                self._settings["branch3"],
+                output="wrong_format",
+            )
+
+    def test_app_commit_to_port_output_json(self):
+        app = self._create_app(
+            self._settings["branch1"],
+            self._settings["branch2"],
+            output="json",
+        )
+        commit_sha = self._commit_change_on_branch(self._settings["branch1"])
+        output = app.run()
+        self.assertTrue(output)
+        self.assertIsInstance(output, str)
+        output = json.loads(output)
+        self.assertEqual(output["process"], "port_commits")
+        # A commit could be ported and is put in a "fake PR" without number
+        self.assertEqual(len(output["results"]), 1)
+        self.assertDictEqual(
+            output["results"][""],
+            {
+                "url": "",
+                "author": "",
+                "title": "",
+                "merged_at": "",
+                "missing_commits": [commit_sha],
+            },
+        )
+
+    def test_app_module_to_migrate_output_json(self):
+        app = self._create_app(
+            self._settings["branch2"],
+            self._settings["branch3"],
+            output="json",
+        )
+        output = app.run()
+        self.assertTrue(output)
+        self.assertIsInstance(output, str)
+        output = json.loads(output)
+        self.assertEqual(output["process"], "migrate")
+        self.assertEqual(output["results"], {})

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,47 @@
+import json
+
+import oca_port
+
+from . import common
+
+
+class TestApp(common.CommonCase):
+    def _create_app(self, from_branch, to_branch):
+        params = {
+            "from_branch": from_branch,
+            "to_branch": to_branch,
+            "addon": self._settings["addon"],
+            "upstream_org": self._settings["upstream_org"],
+            "upstream": self._settings["upstream"],
+            "repo_path": self.repo_path,
+            "repo_name": "test",
+            "user_org": self._settings["user_org"],
+            "no_cache": self._settings["no_cache"],
+        }
+        # NOTE: app will run in non-interactive mode
+        return oca_port.App(**params)
+
+    def test_app_nothing_to_port(self):
+        app = self._create_app(self._settings["branch1"], self._settings["branch2"])
+        try:
+            app.run()
+        except SystemExit as exc:
+            # exit code 0 means nothing needs to be migrated/ported
+            self.assertEqual(exc.args[0], 0)
+
+    def test_app_commit_to_port(self):
+        app = self._create_app(self._settings["branch1"], self._settings["branch2"])
+        self._commit_change_on_branch(self._settings["branch1"])
+        try:
+            app.run()
+        except SystemExit as exc:
+            # exit code 110 means pull requests or commits could be ported
+            self.assertEqual(exc.args[0], 110)
+
+    def test_app_module_to_migrate(self):
+        app = self._create_app(self._settings["branch2"], self._settings["branch3"])
+        try:
+            app.run()
+        except SystemExit as exc:
+            # exit code 100 means the module could be migrated
+            self.assertEqual(exc.args[0], 100)


### PR DESCRIPTION
Several things here (see commits):

- Consolidate all parameters and features provided by the tool in a `App` class (used by all subsequent classes to not duplicate parameters everywhere)
- Ability to write scripts using the `oca_port` Python package (and ease the writing of tests! So some basic tests added)
- Different behavior if used as a CLI tool or as a Python package/API (no fancy output in the former)
- If the CLI tool is used with the `--non-interactive` option, 3 exit codes can be returned:
  - `0`: all good, nothing to migrate or port (the Git history is the same on the source & target branches)
  - `100`: the module could be migrated on the target branch
  - `110`: some commits/pull requests could be ported on the target branch for the given module
- New option `--output` to return a parse-able result (working both in CLI mode or through the API) which:
  - enable the `--non-interactive` mode automatically
  - support only JSON for now
- New option `--fetch` option to force the fetch of source & target branches
  - before the fetch was always done, slowing down the process when scanning multiple addons of the same repository
  - now the fetch is only done automatically if no remote branch can be found in the local repository, and it's the responsability of the user to use `--fetch` to update the remote branches (or update them by her/himself)

## Example:
Module already migrated but some commits could be ported:
```sh
$ oca-port 14.0 15.0 auditlog --output=json | jq .
```
```json
{
  "process": "port_commits",
  "results": {
    "2471": {
      "url": "https://github.com/OCA/server-tools/pull/2471",
      "author": "etobella",
      "title": "[OU] auditlog: Improve time of upgrade",
      "merged_at": "2022-11-23T22:20:50Z",
      "missing_commits": [
        "f9976a36bc1c0142e8c803b557859c35bee4d0a1"
      ]
    },
    "2485": {
      "url": "https://github.com/OCA/server-tools/pull/2485",
      "author": "SilvioC2C",
      "title": "[14.0][FIX] auditlog: consistency with Many2one fields",
      "merged_at": "2022-12-07T08:08:30Z",
      "missing_commits": [
        "f52b024ba141fbbde1999ad5fb127720bc28a847"
      ]
    }
  }
}
```
Module alreay migrated and nothing to port:
```sh
$ oca-port 14.0 16.0 shipment_advice --output=json | jq .
{}
```

## TODO:
- [x] run tests with GitHub workflow
- [ ] return the blacklist reason if any

This PR implements (partially) issue #17 