### PR TITLE
Add PR blacklist

### DIFF
--- a/oca_port/cli/pr.py
+++ b/oca_port/cli/pr.py
@@ -1,0 +1,64 @@
+# Copyright 2023 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
+
+import os
+
+import click
+import git
+
+from ..exceptions import RemoteBranchValueError
+from ..utils.git import Branch
+from ..utils.storage import InputStorage
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.argument("prs", required=True)
+@click.argument("target_branch", required=True)
+@click.argument("addon", required=True)
+@click.option(
+    "--reason",
+    default="Nothing to port from PR #{pr_number}",
+    show_default=True,
+)
+@click.option(
+    "--remote",
+    default="origin",
+    show_default=True,
+)
+def blacklist(
+    prs: str,
+    target_branch: str,
+    addon: str,
+    reason: str,
+    remote: str,
+):
+    """Blacklist one or more PRs"""
+    # eg: https://github.com/user/repo/pull/1234 or just the number
+    pr_numbers = [x.strip() for x in prs.split(",") if x.strip()]
+
+    # TODO: we assume you are in the right repo folder when you run this
+    repo = git.Repo(os.getcwd())
+    if repo.is_dirty(untracked_files=True):
+        raise ValueError("changes not committed detected in this repository.")
+    # Transform branch strings to Branch objects
+    try:
+        branch = Branch(repo, target_branch, default_remote=remote)
+    except ValueError as exc:
+        if exc.args[1] not in repo.remotes:
+            raise RemoteBranchValueError(repo.name, exc.args[1]) from exc
+
+    storage = InputStorage(branch, addon)
+    for pr_number in pr_numbers:
+        storage.blacklist_pr(pr_number, reason=reason.format(pr_number=pr_number))
+    if storage.dirty:
+        msg = f"oca-port: blacklist PR(s) {', '.join(pr_numbers)} for {addon}"
+        storage.commit(msg)
+
+
+if __name__ == "__main__":
+    cli()

--- a/oca_port/utils/storage.py
+++ b/oca_port/utils/storage.py
@@ -102,7 +102,7 @@ class InputStorage:
         self._data["no_migration"] = reason or "Unknown"
         self.dirty = True
 
-    def commit(self):
+    def commit(self, msg=None):
         """Commit all files contained in the storage directory."""
         if not self.save():
             return
@@ -123,5 +123,5 @@ class InputStorage:
         self.repo.index.add(self.storage_dirname)
         if self.repo.is_dirty():
             g.run_pre_commit(self.repo, self.addon, commit=False, hook="prettier")
-            self.repo.index.commit(f"oca-port: store '{self.addon}' data")
+            self.repo.index.commit(msg or f"oca-port: store '{self.addon}' data")
             self.dirty = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "oca_port"
 authors = [
     {name = "Odoo Community Association (OCA)"},
-    {name = "Sébastien Alix", email="sebastien.alix@camptocamp.com"}
+    {name = "Sébastien Alix", email="sebastien.alix@camptocamp.com"},
+    {name = "Simone Orsi", email="simone.orsi@camptocamp.com"}
 ]
 description = "OCA tool to help with modules migration"
 readme = "README.md"
@@ -28,6 +29,7 @@ repository = "https://github.com/OCA/oca-port"
 
 [project.scripts]
 oca-port = "oca_port.cli.main:main"
+oca-port-pr = "oca_port.cli.pr:cli"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
You can now blacklist PR directly when you know some of them do not need any porting.
This could make you save a lot of time by skipping useless analysis and false positives.