### PR TITLE
[FIX] github.search_migration_pr: fix matching of module name in PR title

### DIFF
--- a/oca_port/utils/github.py
+++ b/oca_port/utils/github.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
 
 import os
+import re
 
 import requests
 
@@ -56,7 +57,7 @@ def search_migration_pr(from_org: str, repo_name: str, branch: str, addon: str):
     for pr in prs.get("items", {}):
         # Searching for 'a' on GitHub could return a result containing 'a_b'
         # so we check the result for the exact module name to return a relevant PR.
-        if any(addon == term for term in pr["title"].split()):
+        if _addon_in_text(addon, pr["title"]):
             return PullRequest(
                 number=pr["number"],
                 url=pr["html_url"],
@@ -64,3 +65,8 @@ def search_migration_pr(from_org: str, repo_name: str, branch: str, addon: str):
                 title=pr["title"],
                 body=pr["body"],
             )
+
+
+def _addon_in_text(addon, text):
+    """Return `True` if `addon` is present in `text`."""
+    return any(addon == term for term in re.split(r"\W+", text))

--- a/tests/test_utils_github.py
+++ b/tests/test_utils_github.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from oca_port.utils import github
+
+
+def test_addon_in_text():
+    # Matching OK
+    res = github._addon_in_text("a_b", "[16.0][MIG] a_b: migration to 16.0")
+    assert res
+    # Module name is not the expected one: do not match
+    res = github._addon_in_text("a_b", "[16.0][MIG] a_b_c: migration to 16.0")
+    assert not res


### PR DESCRIPTION
The PR title is split by words without including special characters (this doesn't include `_`).

Before this change, the term to match against could have been `my_module:`, e.g.:
```sh
$ oca-port 14.0 16.0 stock_warehouse_flow --output=json | jq .
{
  "process": "migrate",
  "results": {}
}
```

With this change, the term to match become `my_module`:
```sh
$ oca-port 14.0 16.0 stock_warehouse_flow --output=json | jq .
{
  "process": "migrate",
  "results": {
    "existing_pr": {
      "url": "https://github.com/OCA/wms/pull/704",
      "ref": "OCA/wms#704",
      "author": "RodrigoBM",
      "title": "[16.0][MIG] stock_warehouse_flow: Migration to 16.0",
      "merged_at": "",
      "number": 704
    }
  }
}
```