### PR TITLE
App: make returned result consistent with output options

### DIFF
--- a/oca_port/app.py
+++ b/oca_port/app.py
@@ -172,26 +172,26 @@ class App(Output):
         """Run 'oca-port' to migrate an addon or to port its pull requests."""
         self.check_addon_exists_from_branch(raise_exc=True)
         # Check if some PRs could be ported
-        output = self.run_port()
-        if not output:
+        res, output = self.run_port()
+        if not res:
             # If not, migrate the addon
-            output = self.run_migrate()
+            res, output = self.run_migrate()
         if self.cli and self.output:
             if not output:
                 output = self._render_output(self.output, {})
             print(output)
         if self.clear_cache:
             self.cache.clear()
-        return output
+        if self.output:
+            return output
+        return res
 
     def run_port(self):
         """Port pull requests of an addon (if any)."""
         # Check if the addon (folder) exists on the target branch
         #   - if it already exists, check if some PRs could be ported
-        if self.check_addon_exists_to_branch():
-            return PortAddonPullRequest(self).run()
+        return PortAddonPullRequest(self).run()
 
     def run_migrate(self):
         """Migrate an addon."""
-        if not self.check_addon_exists_to_branch():
-            return MigrateAddon(self).run()
+        return MigrateAddon(self).run()


### PR DESCRIPTION
Extracted from #33 

Depending on the running mode (CLI, non-interactive, JSON output...) the result of `App.run()` has to be consistent with the user parameters:

- with non-interactive and without output, return a boolean or exception:
    - something to migrate/port: `True`
    - nothing to do: `False`
    - module doesn't exist on source branch: `ValueError`
- with a format output defined, return the expected format, e.g. with JSON:
    - something to migrate/port: non-empty JSON document
    - nothing to migrate/port: empty JSON document
    - module doesn't exist on source branch: `ValueError`
- as CLI: return an exit code (+ text printed on std output):
    - something to migrate: 100
    - something to port: 110
    - nothing to migrate/port: 0
    - module doesn't exist on source branch: 1