### PR TITLE
utils.git.Commit: leverage user's cache to get commit file paths

### DIFF
--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -428,6 +428,8 @@ class BranchesDiff(Output):
         )
         self.commits_diff = self.get_commits_diff()
         self.serialized_diff = self._serialize_diff(self.commits_diff)
+        # Once the analyze is done, we store the cache on disk
+        self.app.cache.save()
 
     def _serialize_diff(self, commits_diff):
         data = {}
@@ -453,7 +455,7 @@ class BranchesDiff(Output):
         for commit in commits:
             if self.app.cache.is_commit_ported(commit.hexsha):
                 continue
-            com = g.Commit(commit)
+            com = g.Commit(commit, cache=self.app.cache)
             if self._skip_commit(com):
                 continue
             commits_list.append(com)
@@ -551,7 +553,7 @@ class BranchesDiff(Output):
                         # Ignore commits referenced by a PR but not present
                         # in the stable branches
                         continue
-                    pr_commit = g.Commit(raw_commit)
+                    pr_commit = g.Commit(raw_commit, cache=self.app.cache)
                     if self._skip_commit(pr_commit):
                         continue
                     pr_commit_paths = {

--- a/oca_port/tests/common.py
+++ b/oca_port/tests/common.py
@@ -6,6 +6,8 @@ import time
 import unittest
 from unittest.mock import patch
 
+from oca_port.app import App
+
 import git
 
 
@@ -102,6 +104,21 @@ class CommonCase(unittest.TestCase):
         repo.index.add(self.manifest_path)
         commit = repo.index.commit(f"[FIX] {self._settings['addon']}: fix dependency")
         return commit.hexsha
+
+    def _create_app(self, from_branch, to_branch, **kwargs):
+        params = {
+            "from_branch": from_branch,
+            "to_branch": to_branch,
+            "addon": self._settings["addon"],
+            "from_org": self._settings["from_org"],
+            "from_remote": self._settings["from_remote"],
+            "repo_path": self.repo_path,
+            "repo_name": "test",
+            "user_org": self._settings["user_org"],
+            "no_cache": self._settings["no_cache"],
+        }
+        params.update(kwargs)
+        return App(**params)
 
     def tearDown(self):
         # Clean up the Git repository

--- a/oca_port/tests/test_app.py
+++ b/oca_port/tests/test_app.py
@@ -1,26 +1,9 @@
 import json
 
-from oca_port.app import App
-
 from . import common
 
 
 class TestApp(common.CommonCase):
-    def _create_app(self, from_branch, to_branch, **kwargs):
-        params = {
-            "from_branch": from_branch,
-            "to_branch": to_branch,
-            "addon": self._settings["addon"],
-            "from_org": self._settings["from_org"],
-            "from_remote": self._settings["from_remote"],
-            "repo_path": self.repo_path,
-            "repo_name": "test",
-            "user_org": self._settings["user_org"],
-            "no_cache": self._settings["no_cache"],
-        }
-        params.update(kwargs)
-        return App(**params)
-
     def test_app_nothing_to_port(self):
         app = self._create_app(
             self._settings["remote_branch1"], self._settings["remote_branch2"]

--- a/oca_port/tests/test_utils_cache.py
+++ b/oca_port/tests/test_utils_cache.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from . import common
+
+from oca_port.utils import cache
+
+
+class TestUserCache(common.CommonCase):
+    def setUp(self):
+        super().setUp()
+        app = self._create_app(
+            self._settings["remote_branch1"],
+            self._settings["remote_branch2"],
+            from_org="TEST",
+        )
+        self.cache = cache.UserCache(app)
+
+    def test_commit_ported(self):
+        sha = "TEST"
+        self.assertFalse(self.cache.is_commit_ported(sha))
+        self.cache.mark_commit_as_ported(sha)
+        self.assertTrue(self.cache.is_commit_ported(sha))
+
+    def test_commit_pr(self):
+        sha = "TEST"
+        pr_data = {
+            "number": 10,
+            "title": "TEST",
+        }
+        self.assertFalse(self.cache.get_pr_from_commit(sha))
+        self.cache.store_commit_pr(sha, pr_data)
+        self.assertDictEqual(self.cache.get_pr_from_commit(sha), pr_data)
+
+    def test_commit_files(self):
+        sha = "TEST"
+        files = ["a/b/test", "a/data"]
+        self.assertFalse(self.cache.get_commit_files(sha))
+        self.cache.set_commit_files(sha, files)
+        self.assertEqual(self.cache.get_commit_files(sha), files)


### PR DESCRIPTION
And do not fetch file paths when initializing `Commit` objects, wait for the first access to `Commit.files` or `Commit.paths` attributes to avoid useless IO.

Requesting files modified by a commit is taking quite a lot of time by `git`, especially on big repositories (basically `git show --stat`).

Before this change, the following command is taking about ~2min to execute in `OCA/wms` repository (with others cache already built):
```sh
$ oca-port 14.0 16.0 stock_warehouse_flow --verbose
```
After, it takes ~2s.