### PR TITLE
Refactor main arguments + other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,29 @@ Using
 If the addon does not exist on the target branch, it will assist the user in
 the migration, following the OCA migration guide.
 
-If the addon already exists on the target branch, it will retrieve missing
-commits to port. If a Pull Request exists for a missing commit, it will be
-ported with all its commits if they were not yet (fully) ported.
+If the addon already exists on the target branch, it will retrieve commits
+not fully ported grouped by Pull Request and propose to port them.
+
+Syntax:
+
+    $ oca-port <source> <target> <module> [options]
+    $ oca-port --help
 
 To check if an addon could be migrated or to get eligible commits to port:
 
     $ export GITHUB_TOKEN=<token>
-    $ oca-port 14.0 15.0 shopfloor --verbose
+    $ cd <path/to/OCA/cloned_repository>
+    $ oca-port origin/14.0 origin/16.0 <module> --verbose --dry-run
 
-To effectively migrate the addon or port its commits, use the `--fork` option:
+To effectively migrate the addon or port its commits, remove the `--dry-run` option
+so the tool will create a working local branch automatically (called destination)
+from the `<target>` branch:
 
-    $ oca-port 14.0 15.0 shopfloor --fork camptocamp
+    $ oca-port origin/14.0 origin/16.0 <module>
+
+You can control the destination with the `--destination` option:
+
+    $ oca-port origin/14.0 origin/16.0 <module> --destination camptocamp/16.0-port-things
 
 You can also directly blacklist a bunch of PRs on a given branch thanks to the
 `oca-port-pr` tool:
@@ -88,15 +99,14 @@ You can also use `oca-port` as a Python package:
 ```python
 >>> import oca_port
 >>> app = oca_port.App(
-...     from_branch="14.0",
-...     to_branch="16.0",
+...     source="origin/14.0",
+...     target="origin/16.0",
 ...     addon="stock_move_auto_assign",
-...     from_org": "OCA",
-...     from_remote": "origin",
+...     upstream_org": "OCA",
 ...     repo_path": "/home/odoo/OCA/stock-logistics-warehouse",
 ...     output": "json",
 ...     fetch": True,
-...     github_token: "ghp_sheeXai3xu1yoopheiquoo3ohch0AefooSob"
+...     github_token: "<TOKEN>"
 ... )
 >>> json_data = app.run()
 >>> data = json.loads(json_data)

--- a/oca_port/app.py
+++ b/oca_port/app.py
@@ -194,6 +194,48 @@ class App(Output):
         if self.destination.branch:
             self.dest_branch = self._prepare_branch(self.destination)
 
+        # Print a warning if the repository in the destination remote URL differs
+        # from the repository of the target as we probably want to push under the
+        # same repository name.
+        fishy_parameters = False
+        if not self.dry_run and self.destination.remote and self.target.repo:
+            dest_remote_url = self.repo.remotes[self.destination.remote].url
+            if self.target.repo not in dest_remote_url:
+                fishy_parameters = True
+                self._print(
+                    "⚠️  Destination repository does not match the target. "
+                    "Destination remote is perhaps not the right one."
+                )
+        # Print a summary of source/target/destination
+        if self.verbose or fishy_parameters:
+            source_remote_url = (
+                self.repo.remotes[self.source.remote].url if self.source.remote else ""
+            )
+            msg = f"{bc.BOLD}Source{bc.END}: {self.source.ref}"
+            if source_remote_url:
+                msg += f", remote {bc.BOLD}{self.source.remote} {source_remote_url}{bc.END}"
+            self._print(msg)
+            target_remote_url = (
+                self.repo.remotes[self.target.remote].url if self.target.remote else ""
+            )
+            msg = f"{bc.BOLD}Target{bc.END}: {self.target.ref}"
+            if target_remote_url:
+                msg += f", remote {bc.BOLD}{self.target.remote} {target_remote_url}{bc.END}"
+            self._print(msg)
+            if not self.dry_run:
+                dest_remote_url = (
+                    self.repo.remotes[self.destination.remote].url
+                    if self.destination.remote
+                    else ""
+                )
+                msg = f"{bc.BOLD}Destination{bc.END}: {self.destination.ref}"
+                if dest_remote_url:
+                    msg += (
+                        f", remote {bc.BOLD}{self.destination.remote} "
+                        f"{dest_remote_url}{bc.END}"
+                    )
+                self._print(msg)
+
     def _prepare_branch(self, info):
         try:
             return Branch(self.repo, info.branch, default_remote=info.remote)

--- a/oca_port/cli/pr.py
+++ b/oca_port/cli/pr.py
@@ -44,8 +44,6 @@ def blacklist(
 
     # TODO: we assume you are in the right repo folder when you run this
     repo = git.Repo(os.getcwd())
-    if repo.is_dirty(untracked_files=True):
-        raise ValueError("changes not committed detected in this repository.")
     # Transform branch strings to Branch objects
     try:
         branch = Branch(repo, target_branch, default_remote=remote)

--- a/oca_port/migrate_addon.py
+++ b/oca_port/migrate_addon.py
@@ -105,6 +105,11 @@ class MigrateAddon(Output):
             )
             self._results["results"]["existing_pr"] = existing_pr.to_dict(number=True)
         if self.app.non_interactive or self.app.dry_run:
+            self._print(
+                f"ℹ️  {bc.BOLD}{self.app.addon}{bc.END} can be migrated "
+                f"from {bc.BOLD}{self.app.source_version}{bc.END} "
+                f"to {bc.BOLD}{self.app.target_version}{bc.END}."
+            )
             # If an output is defined we return the result in the expected format
             if self.app.output:
                 return True, self._render_output(self.app.output, self._results)

--- a/oca_port/migrate_addon.py
+++ b/oca_port/migrate_addon.py
@@ -16,27 +16,27 @@ MIG_MERGE_COMMITS_URL = (
     "https://github.com/OCA/maintainer-tools/wiki/Merge-commits-in-pull-requests"
 )
 MIG_TASKS_URL = (
-    "https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-{branch}"
+    "https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-{version}"
     "#tasks-to-do-in-the-migration"
 )
-MIG_NEW_PR_TITLE = "[{to_branch}][MIG] {addon}"
+MIG_NEW_PR_TITLE = "[{version}][MIG] {addon}"
 MIG_NEW_PR_URL = (
     "https://github.com/{from_org}/{repo_name}/compare/"
-    "{to_branch}...{user_org}:{mig_branch}?expand=1&title={title}"
+    "{to_branch}...{to_org}:{mig_branch}?expand=1&title={title}"
 )
 MIG_TIPS = "\n".join(
     [
         f"\n{bc.BOLD}{bc.OKCYAN}The next steps are:{bc.END}",
         ("\t1) Reduce the number of commits " f"('{bc.DIM}OCA Transbot...{bc.END}'):"),
         f"\t\t=> {bc.BOLD}{MIG_MERGE_COMMITS_URL}{bc.END}",
-        "\t2) Adapt the module to the {to_branch} version:",
+        "\t2) Adapt the module to the {version} version:",
         f"\t\t=> {bc.BOLD}" "{mig_tasks_url}" f"{bc.END}",
         (
             "\t3) On a shell command, type this for uploading the content to GitHub:\n"
             f"{bc.DIM}"
             "\t\t$ git add --all\n"
-            '\t\t$ git commit -m "[MIG] {addon}: Migration to {to_branch}"\n'
-            "\t\t$ git push {fork} {mig_branch} --set-upstream"
+            '\t\t$ git commit -m "[MIG] {addon}: Migration to {version}"\n'
+            "\t\t$ git push {remote} {mig_branch} --set-upstream"
             f"{bc.END}"
         ),
         "\t4) Create the PR against {from_org}/{repo_name}:",
@@ -49,7 +49,7 @@ BLACKLIST_TIPS = "\n".join(
         (
             "\t1) On a shell command, type this for uploading the content to GitHub:\n"
             f"{bc.DIM}"
-            "\t\t$ git push {fork} {mig_branch} --set-upstream"
+            "\t\t$ git push {remote} {mig_branch} --set-upstream"
             f"{bc.END}"
         ),
         "\t2) Create the PR against {from_org}/{repo_name}:",
@@ -64,8 +64,11 @@ class MigrateAddon(Output):
         self._results = {"process": "migrate", "results": {}}
         self.mig_branch = g.Branch(
             self.app.repo,
-            MIG_BRANCH_NAME.format(
-                branch=self.app.to_branch.name[:4], addon=self.app.addon
+            (
+                self.app.destination.branch
+                or MIG_BRANCH_NAME.format(
+                    branch=self.app.target_version, addon=self.app.addon
+                )
             ),
         )
 
@@ -85,11 +88,11 @@ class MigrateAddon(Output):
             return False, None
         # Looking for an existing PR to review
         existing_pr = None
-        if self.app.from_org and self.app.repo_name:
+        if self.app.upstream_org and self.app.repo_name:
             existing_pr = self.app.github.search_migration_pr(
-                from_org=self.app.from_org,
+                from_org=self.app.upstream_org,
                 repo_name=self.app.repo_name,
-                branch=self.app.to_branch.name,
+                branch=self.app.target.branch,
                 addon=self.app.addon,
             )
         if existing_pr:
@@ -101,7 +104,7 @@ class MigrateAddon(Output):
                 "Thank you!"
             )
             self._results["results"]["existing_pr"] = existing_pr.to_dict(number=True)
-        if self.app.non_interactive:
+        if self.app.non_interactive or self.app.dry_run:
             # If an output is defined we return the result in the expected format
             if self.app.output:
                 return True, self._render_output(self.app.output, self._results)
@@ -113,17 +116,13 @@ class MigrateAddon(Output):
             return True, None
         confirm = (
             f"Migrate {bc.BOLD}{self.app.addon}{bc.END} "
-            f"from {bc.BOLD}{self.app.from_branch.name}{bc.END} "
-            f"to {bc.BOLD}{self.app.to_branch.name}{bc.END}?"
+            f"from {bc.BOLD}{self.app.source_version}{bc.END} "
+            f"to {bc.BOLD}{self.app.target_version}{bc.END}?"
         )
         if not click.confirm(confirm):
             self.app.storage.blacklist_addon(confirm=True)
             if not self.app.storage.dirty:
                 return False, None
-        # Check if a migration PR already exists
-        # TODO
-        if not self.app.fork:
-            raise click.UsageError("Please set the '--fork' option")
         if self.app.repo.untracked_files:
             raise click.ClickException("Untracked files detected, abort")
         self._checkout_base_branch()
@@ -139,7 +138,7 @@ class MigrateAddon(Output):
             g.run_pre_commit(self.app.repo, self.app.addon)
         # Check if the addon has commits that update neighboring addons to
         # make it work properly
-        PortAddonPullRequest(self.app, create_branch=False, push_branch=False).run()
+        PortAddonPullRequest(self.app, push_branch=False).run()
         self._print_tips()
         return True, None
 
@@ -201,36 +200,36 @@ class MigrateAddon(Output):
         )
 
     def _print_tips(self, blacklisted=False):
-        mig_tasks_url = MIG_TASKS_URL.format(branch=self.app.to_branch.name)
+        mig_tasks_url = MIG_TASKS_URL.format(version=self.app.target_version)
         pr_title_encoded = urllib.parse.quote(
             MIG_NEW_PR_TITLE.format(
-                to_branch=self.app.to_branch.name[:4], addon=self.app.addon
+                version=self.app.target_version, addon=self.app.addon
             )
         )
         new_pr_url = MIG_NEW_PR_URL.format(
-            from_org=self.app.from_org,
+            from_org=self.app.upstream_org,
             repo_name=self.app.repo_name,
             to_branch=self.app.to_branch.name,
-            user_org=self.app.user_org,
+            to_org=self.app.destination.org or "YOUR_ORG",
             mig_branch=self.mig_branch.name,
             title=pr_title_encoded,
         )
         if blacklisted:
             tips = BLACKLIST_TIPS.format(
-                from_org=self.app.from_org,
+                from_org=self.app.upstream_org,
                 repo_name=self.app.repo_name,
-                fork=self.app.fork,
+                remote=self.app.destination.remote,
                 mig_branch=self.mig_branch.name,
                 new_pr_url=new_pr_url,
             )
             print(tips)
             return
         tips = MIG_TIPS.format(
-            from_org=self.app.from_org,
+            from_org=self.app.upstream_org,
             repo_name=self.app.repo_name,
             addon=self.app.addon,
-            to_branch=self.app.to_branch.name,
-            fork=self.app.fork,
+            version=self.app.target_version,
+            remote=self.app.destination.remote or "YOUR_REMOTE",
             mig_branch=self.mig_branch.name,
             mig_tasks_url=mig_tasks_url,
             new_pr_url=new_pr_url,

--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -379,9 +379,10 @@ class PortAddonPullRequest(Output):
         """Port commits of a Pull Request in a new branch."""
         if pr.number:
             self._print(
-                f"- {bc.BOLD}{bc.OKCYAN}Port PR #{pr.number}{bc.END} "
-                f"({pr.url}) {bc.OKCYAN}{pr.title}{bc.ENDC}..."
+                f"- {bc.BOLD}{bc.OKCYAN}Port PR {pr.ref}{bc.END} "
+                f"{bc.OKCYAN}{pr.title}{bc.ENDC}..."
             )
+            self._print(f"\t{pr.url}")
         else:
             self._print(f"- {bc.BOLD}{bc.OKCYAN}Port commits w/o PR{bc.END}...")
         # Ask the user if he wants to port the PR (or orphaned commits)
@@ -681,8 +682,8 @@ class BranchesDiff(Output):
         for i, pr in enumerate(self.commits_diff, 1):
             if pr.number:
                 lines_to_print.append(
-                    f"{i}) {bc.BOLD}{bc.OKBLUE}PR #{pr.number}{bc.END} "
-                    f"({pr.url or 'w/o PR'}) {bc.OKBLUE}{pr.title}{bc.ENDC}:"
+                    f"{i}) {bc.BOLD}{bc.OKBLUE}{pr.ref}{bc.END} "
+                    f"{bc.OKBLUE}{pr.title}{bc.ENDC}:"
                 )
                 lines_to_print.append(f"\tBy {pr.author}, merged at {pr.merged_at}")
             else:
@@ -700,6 +701,8 @@ class BranchesDiff(Output):
                 f"\t=> {bc.BOLD}{bc.OKBLUE}{len(self.commits_diff[pr])} "
                 f"commit(s){bc.END} not (fully) ported"
             )
+            if pr.number:
+                lines_to_print.append(f"\t=> {pr.url}")
             if verbose or not pr.number:
                 for commit in self.commits_diff[pr]:
                     lines_to_print.append(

--- a/oca_port/tests/test_app.py
+++ b/oca_port/tests/test_app.py
@@ -1,13 +1,71 @@
 import json
 
+from oca_port.utils.misc import extract_ref_info
+
 from . import common
 
 
 class TestApp(common.CommonCase):
+    def test_app_init(self):
+        # Simple case: call oca-port only with SOURCE, TARGET and ADDON parameters
+        # Check with --dry-run option
+        #   $ oca-port origin/15.0 origin/16.0 my_module --dry-run
+        app = self._create_app(self.source1, self.target1, dry_run=True)
+        # Check without --dry-run option
+        #   $ oca-port origin/15.0 origin/16.0 my_module
+        app = self._create_app(self.source1, self.target1)
+        self.assertEqual(app.destination.org, app.target.org)
+        self.assertEqual(app.destination.remote, app.target.remote)
+        self.assertEqual(app.destination.repo, app.target.repo)
+        self.assertEqual(app.destination.branch, None)  # Is automatically set later
+        # Check without --dry-run option and with a different destination
+        #   $ oca-port origin/15.0 origin/16.0 --destination FORK/dev my_module
+        app = self._create_app(self.source1, self.target1, destination=self.destination)
+        self.assertFalse(app.destination.org)
+        self.assertEqual(app.destination.remote, self.fork_org)
+        self.assertEqual(app.destination.branch, self.dest_branch)
+
+        # Check with a branch that doesn't exist
+        #   $ oca-port origin/15.0 14.0
+        error_msg = "Ref 14.0 doesn't exist."
+        with self.assertRaisesRegex(ValueError, error_msg):
+            self._create_app(self.source1, "14.0")
+        #   $ oca-port 14.0 origin/15.0
+        with self.assertRaisesRegex(ValueError, error_msg):
+            self._create_app("14.0", self.target1)
+
+        # Check with a branch that doesn't match an Odoo version
+        #   $ oca-port origin/15.0 dev
+        error_msg = "Unable to identify Odoo target version from dev."
+        with self.assertRaisesRegex(ValueError, error_msg):
+            self._create_app(self.source1, "dev")
+        #   $ oca-port dev origin/15.0
+        error_msg = "Unable to identify Odoo source version from dev."
+        with self.assertRaisesRegex(ValueError, error_msg):
+            self._create_app("dev", self.target1)
+
+        # Check with a local branch matching an Odoo version as target
+        #   $ oca-port origin/15.0 16.0 my_module
+        # NOTE: ensure the local branch exists first
+        repo = self._git_repo(self.repo_path)
+        repo.remotes["origin"].fetch("16.0:16.0")
+        app = self._create_app(self.source1, "16.0")
+        self.assertFalse(app.target.org)
+        self.assertEqual(app.target.branch, "16.0")
+        self.assertFalse(app.destination.org)
+        self.assertFalse(app.destination.remote)
+        self.assertFalse(app.destination.branch)
+        self.assertFalse(app.destination.branch)
+
+    def test_check_addon_exists(self):
+        app = self._create_app(self.source1, self.target2)
+        # source
+        self.assertTrue(app.check_addon_exists_from_branch())
+        # target
+        self.assertFalse(app.check_addon_exists_to_branch())
+
     def test_app_nothing_to_port(self):
-        app = self._create_app(
-            self._settings["remote_branch1"], self._settings["remote_branch2"]
-        )
+        app = self._create_app(self.source1, self.target1)
         try:
             app.run()
         except SystemExit as exc:
@@ -15,14 +73,10 @@ class TestApp(common.CommonCase):
             self.assertEqual(exc.args[0], 0)
 
     def test_app_commit_to_port(self):
-        self._commit_change_on_branch(
-            self.repo_upstream_path, self._settings["branch1"]
-        )
-        app = self._create_app(
-            self._settings["remote_branch1"],
-            self._settings["remote_branch2"],
-            fetch=True,
-        )
+        repo = self._git_repo(self.repo_path)
+        source1 = extract_ref_info(repo, "source", self.source1)
+        self._commit_change_on_branch(self.repo_upstream_path, source1.branch)
+        app = self._create_app(self.source1, self.target1, fetch=True)
         try:
             app.run()
         except SystemExit as exc:
@@ -30,16 +84,12 @@ class TestApp(common.CommonCase):
             self.assertEqual(exc.args[0], 110)
         # The other way around, no commit to backport (no exception)
         # (with CLI, the returned exit code is then 0)
-        app = self._create_app(
-            self._settings["remote_branch2"], self._settings["remote_branch1"]
-        )
+        app = self._create_app(self.target1, self.source1)
         res = app.run()
         self.assertFalse(res)
 
     def test_app_module_to_migrate(self):
-        app = self._create_app(
-            self._settings["remote_branch2"], self._settings["remote_branch3"]
-        )
+        app = self._create_app(self.source2, self.target2)
         try:
             app.run()
         except SystemExit as exc:
@@ -47,20 +97,18 @@ class TestApp(common.CommonCase):
             self.assertEqual(exc.args[0], 100)
         # The other way around, nothing to migrate as the module doesn't exist
         # (with CLI, the returned exit code is then 1)
-        app = self._create_app(
-            self._settings["remote_branch3"], self._settings["remote_branch2"]
-        )
+        app = self._create_app(self.target2, self.source2)
         error_msg = "my_module does not exist on origin/17.0"
         with self.assertRaisesRegex(ValueError, error_msg):
             app.run()
 
     def test_app_commit_to_port_non_interactive(self):
-        self._commit_change_on_branch(
-            self.repo_upstream_path, self._settings["branch1"]
-        )
+        repo = self._git_repo(self.repo_path)
+        source1 = extract_ref_info(repo, "source", self.source1)
+        self._commit_change_on_branch(self.repo_upstream_path, source1.branch)
         app = self._create_app(
-            self._settings["remote_branch1"],
-            self._settings["remote_branch2"],
+            self.source1,
+            self.target1,
             non_interactive=True,
             fetch=True,
         )
@@ -68,30 +116,22 @@ class TestApp(common.CommonCase):
         self.assertTrue(result)
         self.assertIsInstance(result, bool)
         # The other way around, no commit to backport
-        app = self._create_app(
-            self._settings["remote_branch2"],
-            self._settings["remote_branch1"],
-            non_interactive=True,
-        )
+        app = self._create_app(self.target1, self.source1, non_interactive=True)
         result = app.run()
         self.assertFalse(result)
         self.assertIsInstance(result, bool)
 
     def test_app_module_to_migrate_non_interactive(self):
         app = self._create_app(
-            self._settings["remote_branch2"],
-            self._settings["remote_branch3"],
+            self.source2,
+            self.target2,
             non_interactive=True,
         )
         result = app.run()
         self.assertTrue(result)
         self.assertIsInstance(result, bool)
         # The other way around, nothing to migrate as the module doesn't exist
-        app = self._create_app(
-            self._settings["remote_branch3"],
-            self._settings["remote_branch2"],
-            non_interactive=True,
-        )
+        app = self._create_app(self.target2, self.source2, non_interactive=True)
         error_msg = "my_module does not exist on origin/17.0"
         with self.assertRaisesRegex(ValueError, error_msg):
             app.run()
@@ -99,18 +139,20 @@ class TestApp(common.CommonCase):
     def test_app_wrong_output(self):
         with self.assertRaisesRegex(ValueError, "Supported outputs are"):
             self._create_app(
-                self._settings["remote_branch2"],
-                self._settings["remote_branch3"],
+                self.source2,
+                self.target2,
                 output="wrong_format",
             )
 
     def test_app_commit_to_port_output_json(self):
+        repo = self._git_repo(self.repo_path)
+        source1 = extract_ref_info(repo, "source", self.source1)
         commit_sha = self._commit_change_on_branch(
-            self.repo_upstream_path, self._settings["branch1"]
+            self.repo_upstream_path, source1.branch
         )
         app = self._create_app(
-            self._settings["remote_branch1"],
-            self._settings["remote_branch2"],
+            self.source1,
+            self.target1,
             output="json",
             fetch=True,
         )
@@ -133,11 +175,7 @@ class TestApp(common.CommonCase):
             },
         )
         # The other way around, no commit to backport
-        app = self._create_app(
-            self._settings["remote_branch2"],
-            self._settings["remote_branch1"],
-            output="json",
-        )
+        app = self._create_app(self.target1, self.source1, output="json")
         output = app.run()
         self.assertTrue(output)
         self.assertIsInstance(output, str)
@@ -146,8 +184,8 @@ class TestApp(common.CommonCase):
 
     def test_app_module_to_migrate_output_json(self):
         app = self._create_app(
-            self._settings["remote_branch2"],
-            self._settings["remote_branch3"],
+            self.source2,
+            self.target2,
             output="json",
         )
         output = app.run()
@@ -157,11 +195,7 @@ class TestApp(common.CommonCase):
         self.assertEqual(output["process"], "migrate")
         self.assertEqual(output["results"], {})
         # The other way around, nothing to migrate as the module doesn't exist
-        app = self._create_app(
-            self._settings["remote_branch3"],
-            self._settings["remote_branch2"],
-            output="json",
-        )
+        app = self._create_app(self.target2, self.source2, output="json")
         error_msg = "my_module does not exist on origin/17.0"
         with self.assertRaisesRegex(ValueError, error_msg):
             app.run()

--- a/oca_port/tests/test_utils_cache.py
+++ b/oca_port/tests/test_utils_cache.py
@@ -15,6 +15,15 @@ class TestUserCache(common.CommonCase):
             from_org="TEST",
         )
         self.cache = cache.UserCache(app)
+        # As source branch as no organization, cache is by default readonly.
+        # Unset this to run tests.
+        self.cache.readonly = False
+        # Clear the cache before each test
+        self.cache.clear()
+
+    def tearDown(self):
+        # Clear the cache after each test
+        self.cache.clear()
 
     def test_commit_ported(self):
         sha = "TEST"

--- a/oca_port/tests/test_utils_cache.py
+++ b/oca_port/tests/test_utils_cache.py
@@ -9,11 +9,7 @@ from oca_port.utils import cache
 class TestUserCache(common.CommonCase):
     def setUp(self):
         super().setUp()
-        app = self._create_app(
-            self._settings["remote_branch1"],
-            self._settings["remote_branch2"],
-            from_org="TEST",
-        )
+        app = self._create_app(self.source1, self.target1, upstream_org="TEST")
         self.cache = cache.UserCache(app)
         # As source branch as no organization, cache is by default readonly.
         # Unset this to run tests.

--- a/oca_port/tests/test_utils_misc.py
+++ b/oca_port/tests/test_utils_misc.py
@@ -11,6 +11,8 @@ from contextlib import contextmanager
 
 from oca_port.utils import misc
 
+from . import common
+
 
 @contextmanager
 def make_tmp_addon(name, manifest_name="__manifest__.py"):
@@ -30,35 +32,67 @@ def capture_stdout():
     sys.stdout = sys.__stdout__
 
 
-def test_get_manifest_path():
-    with make_tmp_addon("foo") as addons_path:
-        expected = f"{addons_path}/foo/__manifest__.py"
-        assert misc.get_manifest_path(addons_path / "foo") == expected
+class TestMisc(common.CommonCase):
+    def test_get_manifest_path(self):
+        with make_tmp_addon("foo") as addons_path:
+            expected = f"{addons_path}/foo/__manifest__.py"
+            assert misc.get_manifest_path(addons_path / "foo") == expected
 
+    def test_clean_text(self):
+        assert misc.clean_text("[13.0] foo 13.0") == "foo"
 
-def test_clean_text():
-    assert misc.clean_text("[13.0] foo 13.0") == "foo"
+    def test_default_dict_from_dict(self):
+        res = misc.defaultdict_from_dict({"a": 1})
+        # original values preserved
+        assert res["a"] == 1
+        # any key is a dict by default
+        assert isinstance(res["b"], defaultdict)
+        assert isinstance(res["b"]["c"], defaultdict)
+        assert isinstance(res["b"]["c"]["d"], defaultdict)
 
+    def test_output_cli_mode(self):
+        output = misc.Output()
+        output.cli = True
+        output.output = None
+        with capture_stdout() as captured:
+            output._print("foo")
+            output._print("baz")
+            output._print("bar")
+            captured.seek(0)
+            assert captured.read() == "foo\nbaz\nbar\n"
 
-def test_default_dict_from_dict():
-    res = misc.defaultdict_from_dict({"a": 1})
-    # original values preserved
-    assert res["a"] == 1
-    # any key is a dict by default
-    assert isinstance(res["b"], defaultdict)
-    assert isinstance(res["b"]["c"], defaultdict)
-    assert isinstance(res["b"]["c"]["d"], defaultdict)
+        assert output._render_output("json", {"a": 1}) == '{"a": 1}'
 
+    def test_extract_ref_info_http(self):
+        repo = self._git_repo(self.repo_path)
+        org, repo_name, remote, branch = "Example", "test_repo", "test_ref", "16.0"
+        repo.create_remote(remote, f"https://user:pwd@github.com/{org}/{repo_name}.git")
+        ref = f"{remote}/{branch}"
+        expected_info = {
+            "ref": ref,
+            "kind": "source",
+            "branch": branch,
+            "remote": remote,
+            "repo": repo_name,
+            "org": org,
+            "platform": "github",
+        }
+        info = misc.extract_ref_info(repo, "source", ref)
+        self.assertDictEqual(info, expected_info)
 
-def test_output_cli_mode():
-    output = misc.Output()
-    output.cli = True
-    output.output = None
-    with capture_stdout() as captured:
-        output._print("foo")
-        output._print("baz")
-        output._print("bar")
-        captured.seek(0)
-        assert captured.read() == "foo\nbaz\nbar\n"
-
-    assert output._render_output("json", {"a": 1}) == '{"a": 1}'
+    def test_extract_ref_info_ssh(self):
+        repo = self._git_repo(self.repo_path)
+        org, repo_name, remote, branch = "Example", "test_repo", "test_ref", "16.0"
+        repo.create_remote(remote, f"git@github.com:{org}/{repo_name}.git")
+        ref = f"{remote}/{branch}"
+        expected_info = {
+            "ref": ref,
+            "kind": "source",
+            "branch": branch,
+            "remote": remote,
+            "repo": repo_name,
+            "org": org,
+            "platform": "github",
+        }
+        info = misc.extract_ref_info(repo, "source", ref)
+        self.assertDictEqual(info, expected_info)

--- a/oca_port/tests/test_utils_session.py
+++ b/oca_port/tests/test_utils_session.py
@@ -1,0 +1,30 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from . import common
+
+from oca_port.utils import session
+
+
+class TestSession(common.CommonCase):
+    def setUp(self):
+        super().setUp()
+        app = self._create_app(self.source1, self.target1, upstream_org="TEST")
+        self.session_name = "test"
+        self.session = session.Session(app, self.session_name)
+        # Clear the session before each test
+        self.session.clear()
+
+    def tearDown(self):
+        # Clear the session after each test
+        self.session.clear()
+
+    def test_session(self):
+        key = "test"
+        value = ["a", "b"]
+        data = self.session.get_data()
+        self.assertFalse(data)
+        data[key] = value
+        self.session.set_data(data)
+        data2 = self.session.get_data()
+        self.assertEqual(data2, data)

--- a/oca_port/utils/__init__.py
+++ b/oca_port/utils/__init__.py
@@ -1,7 +1,8 @@
-__all__ = ["cache", "git", "github", "misc", "storage"]
+__all__ = ["cache", "git", "github", "misc", "session", "storage"]
 
 from . import cache
 from . import git
 from . import github
 from . import misc
+from . import session
 from . import storage

--- a/oca_port/utils/cache.py
+++ b/oca_port/utils/cache.py
@@ -83,7 +83,8 @@ class UserCache:
     """Manage the user's cache, in respect to XDG conventions.
 
     This class manages the following data:
-        - a list of already ported commits from one branch to another.
+        - a list of already ported commits from one branch to another
+        - some commits data like impacted file paths
 
     It allows to speed up further commit scans on a given module.
     """
@@ -226,6 +227,12 @@ class UserCache:
             pass
 
     def clear(self):
-        """Clear the cache by removing the content of the cache directory."""
-        if self._cache_dirname and str(self.dir_path).endswith(self._cache_dirname):
-            shutil.rmtree(self.dir_path)
+        """Clear the cache files."""
+        paths = [
+            self._ported_commits_path,
+            self._commits_to_port_path,
+            self._commits_data_path,
+        ]
+        for path in paths:
+            if path and path.exists():
+                path.unlink()

--- a/oca_port/utils/cache.py
+++ b/oca_port/utils/cache.py
@@ -5,7 +5,6 @@ import json
 import logging
 import os
 import pathlib
-import shutil
 from collections import defaultdict
 
 from . import misc
@@ -97,6 +96,11 @@ class UserCache:
     def __init__(self, app):
         """Initialize user's cache manager."""
         self.app = app
+        # NOTE: set cache as readonly if the source branch is not linked to
+        # an organization (local branch): we cannot put in cache commits data
+        # coming from such branch in the behalf of upstream organization/repo,
+        # that could produce wrong cache results for further use.
+        self.readonly = not self.app.source.org
         self.dir_path = self._get_dir_path()
         self._ported_commits_path = self._get_ported_commits_path()
         self._ported_commits = self._get_ported_commits()
@@ -121,7 +125,7 @@ class UserCache:
         )
         return self.dir_path.joinpath(
             self._ported_dirname,
-            self.app.from_org,
+            self.app.upstream_org,
             self.app.repo_name,
             file_name,
         )
@@ -134,7 +138,7 @@ class UserCache:
         )
         return self.dir_path.joinpath(
             self._to_port_dirname,
-            self.app.from_org,
+            self.app.upstream_org,
             self.app.repo_name,
             file_name,
         )
@@ -144,7 +148,7 @@ class UserCache:
         file_name = f"{self.app.repo_name}.json"
         return self.dir_path.joinpath(
             self._commits_data_dirname,
-            self.app.from_org,
+            self.app.upstream_org,
             file_name,
         )
 
@@ -181,6 +185,8 @@ class UserCache:
 
     def mark_commit_as_ported(self, commit_sha: str):
         """Mark commit as ported."""
+        if self.readonly:
+            return
         if self.is_commit_ported(commit_sha):
             return
         self._ported_commits.append(commit_sha)
@@ -193,6 +199,8 @@ class UserCache:
 
     def store_commit_pr(self, commit_sha: str, data):
         """Store the original PR data of a commit."""
+        if self.readonly:
+            return
         pr_number = data["number"]
         self._commits_to_port["pull_requests"][str(pr_number)] = data
         self._commits_to_port["commits"][commit_sha]["pr"] = pr_number
@@ -210,10 +218,14 @@ class UserCache:
 
     def set_commit_files(self, commit_sha: str, files: list):
         """Set file paths modified by a commit."""
+        if self.readonly:
+            return
         self._commits_data[commit_sha]["files"] = list(files)
 
     def save(self):
         """Save cache files."""
+        if self.readonly:
+            return
         # commits/PRs to port
         self._save_cache(self._commits_to_port, self._commits_to_port_path)
         # commits data file

--- a/oca_port/utils/git.py
+++ b/oca_port/utils/git.py
@@ -290,7 +290,7 @@ def run_pre_commit(repo, addon, commit=True, hook=None):
         repo.git.add("-A")
         if commit:
             repo.git.commit(
-                "-m", f"[IMP] {addon}: apply pre-commit auto fixes", "--no-verify"
+                "-m", f"[IMP] {addon}: pre-commit auto fixes", "--no-verify"
             )
 
 

--- a/oca_port/utils/session.py
+++ b/oca_port/utils/session.py
@@ -1,0 +1,81 @@
+# Copyright 2024 Camptocamp SA
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
+
+import hashlib
+import json
+import os
+import pathlib
+from collections import defaultdict
+
+from . import misc
+
+
+class Session:
+    """Manage the user's session data, in respect to XDG conventions.
+
+    This class is used to store the list of processed/blacklisted PRs or modules
+    during a porting session.
+    """
+
+    _cache_dirname = "oca-port"
+    _sessions_dirname = "sessions"
+
+    def __init__(self, app, name):
+        """Initialize user's session manager."""
+        self.app = app
+        self.dir_path = self._get_dir_path()
+        self._sessions_dir_path = self._get_sessions_dir_path()
+        self._key = hashlib.md5(name.encode()).hexdigest()
+        session_file = f"{self._key}.json"
+        self._session_path = self._sessions_dir_path.joinpath(session_file)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.clear()
+
+    @classmethod
+    def _get_dir_path(cls):
+        """Return the path of the session directory."""
+        default_cache_dir_path = pathlib.Path.home().joinpath(".cache")
+        return pathlib.Path(
+            os.environ.get("XDG_CACHE_HOME", default_cache_dir_path),
+            cls._cache_dirname,
+        )
+
+    def _get_sessions_dir_path(self):
+        """Return the dir path storing sessions data."""
+        return self.dir_path.joinpath(
+            self._sessions_dirname,
+            self.app.upstream_org,
+        )
+
+    def get_data(self):
+        """Return the data of the session."""
+        try:
+            with self._session_path.open() as file_:
+                return json.load(file_, object_hook=misc.defaultdict_from_dict)
+        except (json.JSONDecodeError, FileNotFoundError):
+            # Mainly to handle empty files (first initialization of the session)
+            # but also to not crash if JSON files get corrupted.
+            # Returns a "nested dict" object to not worry about checking keys
+            nested_dict = lambda: defaultdict(nested_dict)  # noqa
+            return nested_dict()
+
+    def set_data(self, data):
+        """Store `data` for the given `session`."""
+        self._sessions_dir_path.mkdir(parents=True, exist_ok=True)
+        self._save_data(data, self._session_path)
+
+    def _save_data(self, data, path):
+        try:
+            with path.open(mode="w") as file_:
+                json.dump(data, file_, indent=2)
+        except Exception:
+            pass
+
+    def clear(self):
+        """Clear the session file."""
+        if self._session_path and self._session_path.exists():
+            self._session_path.unlink()

--- a/oca_port/utils/session.py
+++ b/oca_port/utils/session.py
@@ -25,8 +25,12 @@ class Session:
         self.app = app
         self.dir_path = self._get_dir_path()
         self._sessions_dir_path = self._get_sessions_dir_path()
-        self._key = hashlib.md5(name.encode()).hexdigest()
-        session_file = f"{self._key}.json"
+        self._key = hashlib.shake_256(name.encode()).hexdigest(3)
+        session_file = (
+            f"{self.app.addon}"
+            f"-{self.app.source_version}-{self.app.target_version}"
+            f"-{self._key}.json"
+        )
         self._session_path = self._sessions_dir_path.joinpath(session_file)
 
     def __enter__(self):

--- a/oca_port/utils/storage.py
+++ b/oca_port/utils/storage.py
@@ -82,9 +82,7 @@ class InputStorage:
         pr_ref = str(pr_ref or "orphaned_commits")
         return self._data.get("pull_requests", {}).get(pr_ref, False)
 
-    def blacklist_pr(self, pr_ref, confirm=False, reason=None):
-        if confirm and not click.confirm("\tBlacklist this PR?"):
-            return
+    def blacklist_pr(self, pr_ref, reason=None):
         if not reason:
             reason = click.prompt("\tReason", type=str)
         pr_ref = str(pr_ref or "orphaned_commits")
@@ -116,11 +114,6 @@ class InputStorage:
         if self.repo.is_dirty() and not all_in_storage:
             raise click.ClickException(
                 "changes not committed detected in this repository."
-            )
-        # Ensure to be on a dedicated branch
-        if self.repo.active_branch.name == self.to_branch.name:
-            raise click.ClickException(
-                "performing commit on upstream branch is not allowed."
             )
         # Commit all changes under ./.oca-port
         self.repo.index.add(self.storage_dirname)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "click",
     "gitpython",
     "requests",
+    "giturlparse",
 ]
 requires-python = ">=3.8"
 dynamic = ["version"]


### PR DESCRIPTION
### Context

This is a rework of #33 , and bring breaking changes, both for CLI tool and API if used as a Python package.

### Description

Introduce 3 concepts:

* source: source of the comparison
* target: target of the comparison
* destination: where to push the work done

All of them accept git `[remote/]branch` references, so additional info like repository and organization is retrieved from the remote URL.

This is also a preliminary step to support porting from one repo to another (very handy in case of modules moved to different repos).

CLI syntax changed to this:

    $ oca-port origin/14.0 origin/16.0 my_module [--destination camptocamp/dev]

A local `dev` branch where commits have already been ported can be resumed this way:

    $ oca-port origin/14.0 dev my_module --target-version=16.0 [--destination camptocamp/dev]

Here we are forced to use an additional parameter `--target-version` as the tool is unable to guess it from `dev` name.

A new `--dry-run` option has been added too:

    $ oca-port origin/14.0 origin/16.0 my_module --dry-run

If no remote is defined (detected from destination or target), porting can still be done but the development branch won't be pushed, nor the PR open against the expected repository. However, a brief PR description will be proposed to the user at the end of the session so he'll be able to open the PR by its own if needed:
![image](https://github.com/user-attachments/assets/cc599437-b987-4946-a885-baecb5c24902)

Remote is not mandatory for `source`, `target` and `destination`, so we can work fully with local branches:

    $ oca-port 14.0 16.0 my_module --destination 16.0-port-things

Another improvement is that `PortAddonPullRequest` class doesn't create one branch for each ported PR, resulting in tons of branches created during a porting session. Instead, the destination branch is used (if provided) or one will be created automatically (name based on list of PRs to port, so re-running the command twice generates the same branch name in
most use cases). Of course, setting your own destination branch is recommended to preserve the full control of your porting session.

Also, the blacklisting of PRs/modules have been refactored to not create files to commit in the middle of a porting session. Instead, if a PR is set as blacklisted, this information will be stored in the user's session and commited at the end of the porting session. If for any reason the porting session is interrupted, such data are not lost when re-running the command again, and the user will be prompted if he still wants to blacklist such PR:
![image](https://github.com/user-attachments/assets/a1779c84-895b-4652-b427-c4f812e28a45)

### How to install and test this PR
```sh
$ pip install -U git+https://github.com/OCA/oca-port.git@refs/pull/51/head
```

### Examples

Run a comparison for `stock_restrict_lot`  in verbose mode first in `--dry-run` with `--fetch` to ensure we get the last changes locally:
```sh
$ oca-port origin/14.0 origin/16.0 stock_restrict_lot --verbose --dry-run --fetch
```
![image](https://github.com/user-attachments/assets/c8a8dd8e-35b5-4f5a-b6d5-25e2fc5c93f4)
This had the effect to put some data in the user's cache, so further similar commands will be faster to run.

Re-run the same command without `--dry-run` nor `--fetch`, but with `--destination` (here a local branch) to not let the tool generates the destination branch automatically:
```sh
$ oca-port origin/14.0 origin/16.0 stock_restrict_lot --verbose --destination=16-port-from-14-stock_restrict_lot
```
![image](https://github.com/user-attachments/assets/3c841ebe-68a3-42e2-9710-e5c70661c4d0)
Up to the user to resolve the conflicts manually (then `git add [...] && git am --continue` or `git am --skip`) before continuing the porting session. Answering no will perform a `git am --abort` before trying to port the next commit of the PR (if any), or propose to port the next PR.

In case the porting session is interrupted, we can resume it by changing restarting the comparison using our destination branch also as the target (with the help of `--target-version` so the tool knows which version we are talking about), so already ported commits won't be listed anymore:
```sh
$ oca-port origin/14.0 16-port-from-14-stock_restrict_lot --target-version=16.0 stock_restrict_lot --verbose --destination=16-port-from-14-stock_restrict_lot
```
Running the same command once everything is ported will produce this result:
![image](https://github.com/user-attachments/assets/ff774048-c6eb-4d83-a77a-52f405f44050)

### TODO:

- [x] update the README