### PR TITLE
[IMP] Migrate/port modules located in subfolder (module path as input instead of module name)

### DIFF
--- a/oca_port/cli/main.py
+++ b/oca_port/cli/main.py
@@ -62,7 +62,7 @@ from ..utils.misc import bcolors as bc
 @click.command()
 @click.argument("source", required=True)
 @click.argument("target", required=True)
-@click.argument("addon", required=True)
+@click.argument("addon_path", required=True)
 @click.option(
     "--destination",
     help=("Git reference where work will be pushed, e.g. 'camptocamp/16.0-dev'."),
@@ -99,7 +99,7 @@ from ..utils.misc import bcolors as bc
 @click.option("--no-cache", is_flag=True, help="Disable user's cache.")
 @click.option("--clear-cache", is_flag=True, help="Clear the user's cache.")
 def main(
-    addon: str,
+    addon_path: str,
     source: str,
     target: str,
     destination: str,
@@ -132,7 +132,7 @@ def main(
     """
     try:
         app = App(
-            addon=addon,
+            addon_path=addon_path,
             source=source,
             target=target,
             destination=destination,

--- a/oca_port/migrate_addon.py
+++ b/oca_port/migrate_addon.py
@@ -189,7 +189,7 @@ class MigrateAddon(Output):
             patches_dir,
             f"{self.app.to_branch.ref()}..{self.app.from_branch.ref()}",
             "--",
-            self.app.addon,
+            self.app.addon_path,
         )
 
     def _apply_patches(self, patches_dir):

--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 
 import click
 import git
+import requests
 
 from .utils import git as g, misc
 from .utils.session import Session
@@ -845,12 +846,16 @@ class BranchesDiff(Output):
         # Request GitHub to get them
         if not any("github.com" in remote.url for remote in self.app.repo.remotes):
             return
-        raw_data = self.app.github.get_original_pr(
-            self.app.upstream_org,
-            self.app.repo_name,
-            self.app.from_branch.name,
-            commit.hexsha,
-        )
+        try:
+            raw_data = self.app.github.get_original_pr(
+                self.app.upstream_org,
+                self.app.repo_name,
+                self.app.from_branch.name,
+                commit.hexsha,
+            )
+        except requests.exceptions.ConnectionError:
+            self._print("⚠️  Unable to detect original PR (connection error)")
+            return
         if raw_data:
             # Get all commits of the PR as they could update others addons
             # than the one the user is interested in.

--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -607,7 +607,7 @@ class BranchesDiff(Output):
 
     def __init__(self, app):
         self.app = app
-        self.path = self.app.addon
+        self.path = self.app.addon_path
         self.from_branch_path_commits, _ = self._get_branch_commits(
             self.app.from_branch.ref(), self.path
         )
@@ -649,7 +649,9 @@ class BranchesDiff(Output):
         for commit in commits:
             if self.app.cache.is_commit_ported(commit.hexsha):
                 continue
-            com = g.Commit(commit, cache=self.app.cache)
+            com = g.Commit(
+                commit, addons_path=self.app.addons_rootdir, cache=self.app.cache
+            )
             if self._skip_commit(com):
                 continue
             commits_list.append(com)
@@ -751,7 +753,11 @@ class BranchesDiff(Output):
                         # Ignore commits referenced by a PR but not present
                         # in the stable branches
                         continue
-                    pr_commit = g.Commit(raw_commit, cache=self.app.cache)
+                    pr_commit = g.Commit(
+                        raw_commit,
+                        addons_path=self.app.addons_rootdir,
+                        cache=self.app.cache,
+                    )
                     if self._skip_commit(pr_commit):
                         continue
                     pr_commit_paths = {

--- a/oca_port/tests/common.py
+++ b/oca_port/tests/common.py
@@ -115,7 +115,7 @@ class CommonCase(unittest.TestCase):
             "source": source,
             "target": target,
             "destination": destination,
-            "addon": self.addon,
+            "addon_path": self.addon,
             "source_version": None,
             "target_version": None,
             "repo_path": self.repo_path,


### PR DESCRIPTION
This will allow to use `oca-port` in repositories having modules in subfolders, like `odoo/local-src` as supported by https://github.com/camptocamp/docker-odoo-project.

E.g:
```sh
$ oca-port origin/master origin/18.0 --source-version=14.0 --upstream-org=camptocamp ./odoo/local-src/my_module --verbose --destination sebalix/18.0-mig-my_module
```