### PR TITLE
[FIX] give the priority to the target repository

### DIFF
--- a/oca_port/app.py
+++ b/oca_port/app.py
@@ -185,8 +185,8 @@ class App(Output):
         self.repo_path = pathlib.Path(self.repo_path)
         self.repo_name = (
             self.repo_name
-            or self.source.repo
             or self.target.repo
+            or self.source.repo
             or self.repo_path.absolute().name
         )
         if not self.repo_path:

--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -850,10 +850,11 @@ class BranchesDiff(Output):
         # Request GitHub to get them
         if not any("github.com" in remote.url for remote in self.app.repo.remotes):
             return
+        src_repo_name = self.app.source.repo or self.app.repo_name
         try:
             raw_data = self.app.github.get_original_pr(
                 self.app.upstream_org,
-                self.app.repo_name,
+                src_repo_name,
                 self.app.from_branch.name,
                 commit.hexsha,
             )
@@ -866,7 +867,7 @@ class BranchesDiff(Output):
             # NOTE: commits fetched from PR are already in the right order
             pr_number = raw_data["number"]
             pr_commits_data = self.app.github.request(
-                f"repos/{self.app.upstream_org}/{self.app.repo_name}"
+                f"repos/{self.app.upstream_org}/{src_repo_name}"
                 f"/pulls/{pr_number}/commits?per_page=100"
             )
             pr_commits = [pr["sha"] for pr in pr_commits_data]


### PR DESCRIPTION
Allows to support migration/porting session for modules that have been moved from one repository to another.
The target repository is the one that should have the priority.