### PR TITLE
PortAddonPullRequest: reduce noise by filtering PRs to port

### DIFF
--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -518,20 +518,14 @@ class PortAddonPullRequest(Output):
                 f"[{self.app.target_version}][FW] {self.app.addon}: multiple ports "
                 f"from {self.app.source_version}"
             )
-            lines = [f"- #{pr['number']}" for pr in processed_prs.values()]
-            body = "\n".join(
-                [
-                    f"Port of the following PRs from {self.app.source_version} "
-                    f"to {self.app.target_version}:"
-                ]
-                + lines
-            )
         if len(processed_prs) == 1:
             pr = list(processed_prs.values())[0]
             title = f"[{self.app.target_version}][FW] {pr['title']}"
-            body = (
-                f"Port of #{pr['number']} from {self.app.source_version} "
-                f"to {self.app.target_version}."
+        if processed_prs:
+            lines = [f"- #{pr['number']}" for pr in processed_prs.values()]
+            body = "\n".join(
+                [f"Port from {self.app.source_version} to {self.app.target_version}:"]
+                + lines
             )
         # Handle blacklisted PRs
         if blacklisted_prs:

--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -4,6 +4,7 @@
 import os
 import hashlib
 import itertools
+import pathlib
 import shutil
 import tempfile
 import urllib.parse
@@ -54,9 +55,6 @@ NEW_PR_URL = (
     "{to_branch}...{to_org}:{pr_branch}?expand=1&title={title}"
 )
 
-# Fake PR for commits w/o any PR (used as fallback)
-FAKE_PR = g.PullRequest(*[""] * 6)
-
 
 def path_to_skip(commit_path):
     """Return True if the commit path should not be ported."""
@@ -88,9 +86,12 @@ class PortAddonPullRequest(Output):
             "checking PRs to port..."
         )
         branches_diff = BranchesDiff(self.app)
-        branches_diff.print_diff(self.app.verbose)
+        if branches_diff.commits_diff["addon"]:
+            branches_diff.print_diff(verbose=self.app.verbose)
+        if branches_diff.commits_diff["satellite"]:
+            branches_diff.print_satellite_diff(verbose=self.app.verbose)
         if self.app.non_interactive:
-            if branches_diff.commits_diff:
+            if branches_diff.commits_diff["addon"]:
                 # If an output is defined we return the result in the expected format
                 if self.app.output:
                     self._results["results"] = branches_diff.serialized_diff
@@ -119,11 +120,11 @@ class PortAddonPullRequest(Output):
     def _get_dest_branch_name(self, branches_diff):
         dest_branch_name = self.app.destination.branch
         # Define a destination branch if not set
-        if branches_diff.commits_diff and not dest_branch_name:
+        if branches_diff.commits_diff["addon"] and not dest_branch_name:
             commits_to_port = [
                 commit.hexsha
                 for commit in itertools.chain.from_iterable(
-                    branches_diff.commits_diff.values()
+                    branches_diff.commits_diff["addon"].values()
                 )
             ]
             h = hashlib.shake_256("-".join(commits_to_port).encode())
@@ -142,7 +143,7 @@ class PortAddonPullRequest(Output):
         wip = self._print_wip_session()
         dest_branch_name = self.app.destination.branch
         # Nothing to port
-        if not branches_diff.commits_diff or not dest_branch_name:
+        if not branches_diff.commits_diff["addon"] or not dest_branch_name:
             # Nothing to port while having WIP means the porting is done
             return wip
         # Check if destination branch exists, and create it if not
@@ -194,11 +195,11 @@ class PortAddonPullRequest(Output):
         dest_branch = g.Branch(self.app.repo, dest_branch_name)
         self.app.repo.heads[dest_branch.name].checkout()
         last_pr = (
-            list(branches_diff.commits_diff.keys())[-1]
-            if branches_diff.commits_diff
+            list(branches_diff.commits_diff["addon"].keys())[-1]
+            if branches_diff.commits_diff["addon"]
             else None
         )
-        for pr, commits in branches_diff.commits_diff.items():
+        for pr, commits in branches_diff.commits_diff["addon"].items():
             # Check if PR has been blacklisted in user's session
             if self._is_pr_blacklisted(pr):
                 if self._confirm_pr_blacklisted(pr):
@@ -632,7 +633,7 @@ class BranchesDiff(Output):
 
     def _serialize_diff(self, commits_diff):
         data = {}
-        for pr, commits in commits_diff.items():
+        for pr, commits in commits_diff["addon"].items():
             data[pr.number] = pr.to_dict()
             data[pr.number]["missing_commits"] = [commit.hexsha for commit in commits]
         return data
@@ -686,7 +687,8 @@ class BranchesDiff(Output):
         lines_to_print = []
         fake_pr = None
         i = 0
-        for i, pr in enumerate(self.commits_diff, 1):
+        key = "addon"
+        for i, pr in enumerate(self.commits_diff[key], 1):
             if pr.number:
                 lines_to_print.append(
                     f"{i}) {bc.BOLD}{bc.OKBLUE}{pr.ref}{bc.END} "
@@ -705,20 +707,20 @@ class BranchesDiff(Output):
                 )
                 lines_to_print.append(f"\t=> Not ported: {pr_paths_not_ported}")
             lines_to_print.append(
-                f"\t=> {bc.BOLD}{bc.OKBLUE}{len(self.commits_diff[pr])} "
+                f"\t=> {bc.BOLD}{bc.OKBLUE}{len(self.commits_diff[key][pr])} "
                 f"commit(s){bc.END} not (fully) ported"
             )
             if pr.number:
                 lines_to_print.append(f"\t=> {pr.url}")
             if verbose or not pr.number:
-                for commit in self.commits_diff[pr]:
+                for commit in self.commits_diff[key][pr]:
                     lines_to_print.append(
                         f"\t\t{bc.DIM}{commit.hexsha[:8]} " f"{commit.summary}{bc.ENDD}"
                     )
         if fake_pr:
             # We have commits without PR, adapt the message
             i -= 1
-            nb_commits = len(self.commits_diff[fake_pr])
+            nb_commits = len(self.commits_diff[key][fake_pr])
             message = (
                 f"{bc.BOLD}{bc.OKBLUE}{i} pull request(s){bc.END} "
                 f"and {bc.BOLD}{bc.OKBLUE}{nb_commits} commit(s) w/o "
@@ -733,23 +735,100 @@ class BranchesDiff(Output):
                 f"{self.app.from_branch.ref()} to {self.app.to_branch.ref()}"
             )
         lines_to_print.insert(0, message)
-        if self.commits_diff:
+        if self.commits_diff[key]:
             lines_to_print.insert(1, "")
+        self._print("\n".join(lines_to_print))
+
+    def print_satellite_diff(self, verbose=False):
+        nb_prs = len(self.commits_diff["satellite"])
+        if not nb_prs:
+            return
+        self._print()
+        lines_to_print = []
+        msg = (
+            f"ℹ️  {nb_prs} other PRs related to {bc.OKBLUE}{self.app.addon}{bc.ENDC} "
+            "are also updating satellite modules/root files"
+        )
+        if verbose:
+            msg += ":"
+        lines_to_print.append(msg)
+        paths_ported = []
+        paths_not_ported = []
+        pr_paths_not_ported = sorted(
+            set(
+                itertools.chain.from_iterable(
+                    [pr.paths_not_ported for pr in self.commits_diff["satellite"]]
+                )
+            )
+        )
+        for path in pr_paths_not_ported:
+            path_exists = g.check_path_exists(
+                self.app.repo,
+                self.app.to_branch.ref(),
+                path,
+                rootdir=self.app.addons_rootdir and self.app.addons_rootdir.name,
+            )
+            if path_exists:
+                if verbose:
+                    lines_to_print.append(f"\t{bc.OKGREEN}- {path}{bc.END}")
+                paths_ported.append(path)
+            else:
+                paths_not_ported.append(path)
+        # Print the list of related modules/root files
+        if verbose:
+            if paths_not_ported:
+                # Two cases:
+                # - if we have PRs that could update already migrated modules
+                #   we list them (see above) while displaying only a counter for
+                #   not yet migrated modules.
+                if paths_ported:
+                    lines_to_print.append(
+                        f"\t{bc.DIM}- +{len(paths_not_ported)} modules/root files "
+                        f"not ported{bc.END}"
+                    )
+                # - if we get only PRs that could update non-migrated modules we
+                #   do not display a counter but an exaustive list of these modules.
+                else:
+                    for path in paths_not_ported:
+                        lines_to_print.append(f"\t{bc.DIM}- {path}{bc.END}")
+            if paths_ported:
+                lines_to_print.append("Think about running oca-port on these modules.")
         self._print("\n".join(lines_to_print))
 
     def get_commits_diff(self):
         """Returns the commits which do not exist in `to_branch`, grouped by
         their related Pull Request.
 
-        :return: a dict {PullRequest: {Commit: data, ...}, ...}
+        These PRs are then in turn grouped based on their impacted addons:
+            - if a PR is updating the analyzed module, it'll be put in 'addon' key
+            - if a PR is updating satellite module(s), it'll be put in 'satellite' key
+
+        :return: a dict {
+            'addon': {PullRequest: {Commit: data, ...}, ...},
+            'satellite': {PullRequest: {Commit: data, ...}, ...},
+        }
         """
         commits_by_pr = defaultdict(list)
+        fake_pr = g.PullRequest(*[""] * 6)
+        # 1st loop to collect original PRs and stack orphaned commits in a fake PR
         for commit in self.from_branch_path_commits:
             if commit in self.to_branch_all_commits:
                 self.app.cache.mark_commit_as_ported(commit.hexsha)
                 continue
-            # Get related Pull Request if any
-            pr = self._get_original_pr(commit)
+            # Get related Pull Request if any,
+            # or fallback on a fake PR to host orphaned commits
+            # This call has two effects:
+            #   - put in cache original PRs (so the 2nd loop is faster)
+            #   - stack orphaned commits in fake PR
+            self._get_original_pr(commit, fallback_pr=fake_pr)
+        # 2nd loop to actually analyze the content of commits/PRs
+        for commit in self.from_branch_path_commits:
+            if commit in self.to_branch_all_commits:
+                self.app.cache.mark_commit_as_ported(commit.hexsha)
+                continue
+            # Get related Pull Request if any,
+            # or fallback on a fake PR that hosts orphaned commits
+            pr = self._get_original_pr(commit, fallback_pr=fake_pr)
             if pr:
                 for pr_commit_sha in pr.commits:
                     try:
@@ -821,13 +900,17 @@ class BranchesDiff(Output):
                             break
                     else:
                         commits_by_pr[pr].append(pr_commit)
-            # No related PR: add the commit to the fake PR
-            else:
-                commits_by_pr[FAKE_PR].append(commit)
         # Sort PRs on the merge date (better to port them in the right order).
         # Do not return blacklisted PR.
-        sorted_commits_by_pr = {}
+        sorted_commits_by_pr = {
+            "addon": defaultdict(list),
+            "satellite": defaultdict(list),
+        }
         for pr in sorted(commits_by_pr, key=lambda pr: pr.merged_at or ""):
+            if self._is_pr_updating_addon(pr):
+                key = "addon"
+            else:
+                key = "satellite"
             blacklisted = self.app.storage.is_pr_blacklisted(pr.ref)
             if not blacklisted:
                 # TODO: Backward compat for old tracking only by number
@@ -838,18 +921,31 @@ class BranchesDiff(Output):
                 ) + f" blacklisted ({blacklisted}){bc.ENDD}"
                 self._print(msg)
                 continue
-            sorted_commits_by_pr[pr] = commits_by_pr[pr]
+            sorted_commits_by_pr[key][pr] = commits_by_pr[pr]
         return sorted_commits_by_pr
 
-    def _get_original_pr(self, commit: g.Commit):
-        """Return the original PR of a given commit."""
+    def _is_pr_updating_addon(self, pr):
+        """Check if a PR still needs to update the analyzed addon."""
+        for path in pr.paths_not_ported:
+            path_ = pathlib.Path(path)
+            if path_.name == self.app.addon:
+                return True
+        return False
+
+    def _get_original_pr(self, commit: g.Commit, fallback_pr=None):
+        """Return the original PR of a given commit.
+
+        If `fallback_pr` is provided, it'll be returned with the commit stacked in it.
+
+        This method is taking care of storing in cache the original PR of a commit.
+        """
         # Try to get the data from the user's cache first
         data = self.app.cache.get_pr_from_commit(commit.hexsha)
         if data:
             return g.PullRequest(**data)
         # Request GitHub to get them
         if not any("github.com" in remote.url for remote in self.app.repo.remotes):
-            return
+            return self._handle_fallback_pr(fallback_pr, commit)
         src_repo_name = self.app.source.repo or self.app.repo_name
         try:
             raw_data = self.app.github.get_original_pr(
@@ -860,7 +956,7 @@ class BranchesDiff(Output):
             )
         except requests.exceptions.ConnectionError:
             self._print("⚠️  Unable to detect original PR (connection error)")
-            return
+            return self._handle_fallback_pr(fallback_pr, commit)
         if raw_data:
             # Get all commits of the PR as they could update others addons
             # than the one the user is interested in.
@@ -882,3 +978,11 @@ class BranchesDiff(Output):
             }
             self.app.cache.store_commit_pr(commit.hexsha, data)
             return g.PullRequest(**data)
+        return self._handle_fallback_pr(fallback_pr, commit)
+
+    def _handle_fallback_pr(self, fallback_pr, commit):
+        # Fallback PR hosting orphaned commits
+        if fallback_pr:
+            if commit.hexsha not in fallback_pr.commits:
+                fallback_pr.commits.append(commit.hexsha)
+        return fallback_pr

--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -165,7 +165,7 @@ class PortAddonPullRequest(Output):
                     msg = "ℹ️  To resume the work from this branch, relaunch with:\n\n"
                     cmd = (
                         f"\t{bc.DIM}oca-port {self.app.source.ref} "
-                        f"{dest_branch_name} {self.app.addon} %s{bc.END}"
+                        f"{dest_branch_name} {self.app.addon_path} %s{bc.END}"
                     )
                     opts = []
                     if self.app.source.branch != self.app.source_version:

--- a/oca_port/tests/test_app.py
+++ b/oca_port/tests/test_app.py
@@ -104,6 +104,17 @@ class TestApp(common.CommonCase):
         with self.assertRaisesRegex(ValueError, error_msg):
             app.run()
 
+    def test_app_nothing_to_port_non_interactive(self):
+        app = self._create_app(self.source1, self.target1, non_interactive=True)
+        result = app.run()
+        self.assertFalse(result)
+        self.assertIsInstance(result, bool)
+        # The other way around, no commit to backport
+        app = self._create_app(self.target1, self.source1, non_interactive=True)
+        result = app.run()
+        self.assertFalse(result)
+        self.assertIsInstance(result, bool)
+
     def test_app_commit_to_port_non_interactive(self):
         repo = self._git_repo(self.repo_path)
         source1 = extract_ref_info(repo, "source", self.source1)

--- a/oca_port/tests/test_branches_diff.py
+++ b/oca_port/tests/test_branches_diff.py
@@ -1,0 +1,51 @@
+import os
+import tempfile
+
+from oca_port.port_addon_pr import BranchesDiff
+from oca_port.utils.misc import extract_ref_info
+
+from . import common
+
+
+class TestBranchesDiff(common.CommonCase):
+    def test_without_satellite_changes(self):
+        repo = self._git_repo(self.repo_path)
+        source1 = extract_ref_info(repo, "source", self.source1)
+        self._commit_change_on_branch(self.repo_upstream_path, source1.branch)
+        app = self._create_app(self.source1, self.target1)
+        diff = BranchesDiff(app)
+        self.assertFalse(diff.commits_diff["addon"])
+        self.assertFalse(diff.commits_diff["satellite"])
+
+    def test_with_satellite_changes(self):
+        repo = self._git_repo(self.repo_path)
+        source1 = extract_ref_info(repo, "source", self.source1)
+        # Add a change in another module but in the same commit
+        change_sha = self._commit_change_on_branch(
+            self.repo_upstream_path, source1.branch, add_satellite_change=True
+        )
+        # Port only the commit content related to the analyzed module
+        upstream_repo = self._git_repo(self.repo_upstream_path)
+        upstream_repo.git.checkout("16.0")
+        patches_dir = tempfile.mkdtemp()
+        upstream_repo.git.format_patch(
+            "--keep-subject",
+            "-o",
+            patches_dir,
+            "-1",
+            change_sha,
+            "--",
+            self.addon,
+        )
+        patches = [
+            os.path.join(patches_dir, f) for f in sorted(os.listdir(patches_dir))
+        ]
+        upstream_repo.git.am("-3", "--keep", *patches)
+        # Check if unported change is detected as satellite
+        app = self._create_app(self.source1, self.target1, fetch=True)
+        diff = BranchesDiff(app)
+        self.assertFalse(diff.commits_diff["addon"])
+        self.assertTrue(diff.commits_diff["satellite"])
+        self.assertEqual(
+            list(diff.commits_diff["satellite"].values())[0][0].hexsha, change_sha
+        )

--- a/oca_port/utils/cache.py
+++ b/oca_port/utils/cache.py
@@ -207,7 +207,9 @@ class UserCache:
 
     def get_pr_from_commit(self, commit_sha: str):
         """Return the original PR data of a commit."""
-        pr_number = self._commits_to_port["commits"][commit_sha]["pr"]
+        pr_number = None
+        if commit_sha in self._commits_to_port["commits"]:
+            pr_number = self._commits_to_port["commits"][commit_sha]["pr"]
         if pr_number:
             return self._commits_to_port["pull_requests"][str(pr_number)]
         return {}


### PR DESCRIPTION
Address issue #21 

PRs that are updating both the analyzed module + other ones (here called 'satellite') were listed by `oca-port`, even if the commits related to the analyzed module were already ported, because contributions on these satellite modules were not (yet) ported.

In the context of the analyzed module, this brings noise and such PR should not be proposed to be ported, but only mentioned.

There are now two kinds of detected PRs:

- the ones that are updating the current analyzed module: they are proposed to the user as "to be ported" as usual
- the ones where only satellite modules/files remain to be ported: such modules are now listed (in verbose mode), and the user invited to run `oca-port` on them.

As such PRs with commits updating only satellite modules are not proposed anymore to the user, some modules will now be considered as "Fully ported" instead of still having some "Commits to port", which is accurate from a reporting POV :tada:

Example of interactive output on `shopfloor_mobile` from `OCA/wms`:
![image](https://github.com/user-attachments/assets/3a21aa53-fb6f-4718-8391-415109bdac4f)

Example of JSON output on `stock_storage_type` from `OCA/wms`:
`$ oca-port origin/14.0 origin/16.0 stock_storage_type --verbose --dry-run --output=json | jq .`
**Before**
```json
{
  "process": "port_commits",
  "results": {
    "258": {
      "url": "https://github.com/OCA/wms/pull/258",
      "ref": "OCA/wms#258",
      "author": "sebalix",
      "title": "[13.0->14.0][oca-port-pr-#58] Add stock_storage_type_buffer",
      "merged_at": "2021-08-04T10:25:21Z",
      "missing_commits": [
        "642de1b44a5789900ee42cccb58bd3dd29451cdd",
        "dc09fb6f2834059e05bc3de9377204d589fc3ad8",
        "7775e31b8e6ec7a5dd48a0c081cd429375b9b89e"
      ]
    }
  }
}
```
**After**
```json
{}  # Now considered as "Fully ported"
```

Still in `OCA/wms` repository, for `shopfloor` module this reduces the number of PRs to port **from 34 to 11**.

### TODO
- [x] fix & add tests
