### PR TITLE
[FIX] replace pkg_resources with importlib.metadata

### DIFF
--- a/oca_port/migrate_addon.py
+++ b/oca_port/migrate_addon.py
@@ -4,7 +4,7 @@
 import os
 import tempfile
 import urllib.parse
-import pkg_resources
+from importlib import metadata
 
 import click
 
@@ -154,10 +154,12 @@ class MigrateAddon(Output):
             with tempfile.TemporaryDirectory() as patches_dir:
                 self._generate_patches(patches_dir)
                 self._apply_patches(patches_dir)
-            if pkg_resources.get_distribution("odoo-module-migrator") is None:
-                g.run_pre_commit(self.app.repo, self.app.addon)
-            else:
+
+            try:
+                metadata.metadata("odoo-module-migrator")
                 adapted = self._apply_code_pattern()
+            except metadata.PackageNotFoundError:
+                g.run_pre_commit(self.app.repo, self.app.addon)
         # Check if the addon has commits that update neighboring addons to
         # make it work properly
         PortAddonPullRequest(self.app, push_branch=False).run()
@@ -296,3 +298,4 @@ class MigrateAddon(Output):
             return True
         except KeyboardInterrupt:
             pass
+        return False


### PR DESCRIPTION
### Context
- Before this commit, somehow it results in:

> pkg_resources.DistributionNotFound: The 'odoo-module-migrator' distribution was not found and is required by the application

### This change
- Using try...except
- Take this occasion to use `importlib.metadata`, successor of `pkg_resources`