### PR TITLE
Fix README odoo-module-migrator installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installing
 
 To automatically apply code patterns with [odoo-module-migrator](https://github.com/OCA/odoo-module-migrator), install library with below syntax:
 
-    $ pipx install git+https://github.com/OCA/odoo-module-migrator.git@master
+    $ pipx inject --include-deps  oca-port git+https://github.com/OCA/odoo-module-migrator.git@master
 
 Using
 -----


### PR DESCRIPTION
As the lib is imported in python in ocaport it need to be installed in the same env so use inject instead of install. Also use --include-deps so it make available the cmd line of odoo-module-migrator

@sebalix 