### PR TITLE
fix error when gh is not installed

### DIFF
--- a/oca_port/utils/github.py
+++ b/oca_port/utils/github.py
@@ -93,4 +93,7 @@ class GitHub:
                 ).strip()
             except subprocess.SubprocessError:
                 pass
+            except FileNotFoundError:
+                # gh not intalled or not in path
+                pass
         return token


### PR DESCRIPTION
Without this patch, oca-port crash if you have not github cli installed