### PR TITLE
[IMP] Add support for module renaming

### DIFF
--- a/oca_port/cli/main.py
+++ b/oca_port/cli/main.py
@@ -33,6 +33,10 @@ on the relevant upstream organization:
 
     $ oca-port 14.0 16.0 shopfloor --upstream-org camptocamp
 
+To move/rename a module during its migration (or compare commits of a moved/renamed module):
+
+    $ oca-port origin/16.0 origin/18.0 stock_packaging_calculator --move-to product_packaging_calculator
+
 Migration of addon
 ------------------
 
@@ -63,6 +67,14 @@ from ..utils.misc import bcolors as bc
 @click.argument("source", required=True)
 @click.argument("target", required=True)
 @click.argument("addon_path", required=True)
+@click.option(
+    "--move-to",
+    "target_addon_path",
+    help=(
+        "Expected name/path of the module on 'target'. "
+        "Used to move or rename a module during a migration."
+    ),
+)
 @click.option(
     "--destination",
     help=("Git reference where work will be pushed, e.g. 'camptocamp/16.0-dev'."),
@@ -106,6 +118,7 @@ from ..utils.misc import bcolors as bc
 )
 def main(
     addon_path: str,
+    target_addon_path: str,
     source: str,
     target: str,
     destination: str,
@@ -140,6 +153,7 @@ def main(
     try:
         app = App(
             addon_path=addon_path,
+            target_addon_path=target_addon_path,
             source=source,
             target=target,
             destination=destination,

--- a/oca_port/migrate_addon.py
+++ b/oca_port/migrate_addon.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
 
 import os
+import git_filter_repo as gfr
 import tempfile
 import urllib.parse
 from importlib import metadata
@@ -10,7 +11,7 @@ import click
 
 from .port_addon_pr import PortAddonPullRequest
 from .utils import git as g
-from .utils.misc import Output, bcolors as bc
+from .utils.misc import Output, bcolors as bc, update_terms_in_directory
 
 MIG_BRANCH_NAME = "{branch}-mig-{addon}"
 MIG_MERGE_COMMITS_URL = (
@@ -80,49 +81,32 @@ class MigrateAddon(Output):
             (
                 self.app.destination.branch
                 or MIG_BRANCH_NAME.format(
-                    branch=self.app.target_version, addon=self.app.addon
+                    branch=self.app.target_version, addon=self.app.source.addon
                 )
             ),
         )
 
     def run(self):
-        if self.app.check_addon_exists_to_branch():
+        migrated = self._check_addon_already_migrated()
+        blacklisted = self._check_addon_blacklisted()
+        if migrated or blacklisted:
             if self.app.non_interactive or self.app.dry_run:
                 if self.app.output:
-                    return False, self._render_output(self.app.output, {})
+                    return False, self._render_output(self.app.output, self._results)
             return False, None
-        blacklisted = self.app.storage.is_addon_blacklisted()
-        if blacklisted:
-            self._print(
-                f"{bc.DIM}Migration of {bc.BOLD}{self.app.addon}{bc.END} "
-                f"{bc.DIM}to {self.app.to_branch.name} "
-                f"blacklisted ({blacklisted}){bc.ENDD}"
-            )
-            return False, None
-        # Looking for an existing PR to review
-        existing_pr = None
-        if self.app.upstream_org and self.app.repo_name:
-            existing_pr = self.app.github.search_migration_pr(
-                from_org=self.app.upstream_org,
-                repo_name=self.app.repo_name,
-                branch=self.app.target.branch,
-                addon=self.app.addon,
-            )
-        if existing_pr:
-            self._print(
-                f"⚠️\tMigration of {bc.BOLD}{self.app.addon}{bc.END} "
-                f"seems handled in this PR:\n"
-                f"\t\t{bc.BOLD}{existing_pr.url}{bc.END} (by {existing_pr.author})\n"
-                "\tWe invite you to review this PR instead of opening a new one. "
-                "Thank you!"
-            )
-            self._results["results"]["existing_pr"] = existing_pr.to_dict(number=True)
+        # At this stage, the addon could be migrated
+        self._detect_existing_pr()
         if self.app.non_interactive or self.app.dry_run:
-            self._print(
-                f"ℹ️  {bc.BOLD}{self.app.addon}{bc.END} can be migrated "
+            msg = (
+                f"ℹ️  {bc.BOLD}{self.app.source.addon}{bc.END} can be migrated "
                 f"from {bc.BOLD}{self.app.source_version}{bc.END} "
-                f"to {bc.BOLD}{self.app.target_version}{bc.END}."
+                f"to {bc.BOLD}{self.app.target_version}{bc.END}"
             )
+            if self.app.source.addon_path != self.app.target.addon_path:
+                msg += f" and moved to {bc.BOLD}{self.app.target.addon_path}{bc.END}"
+            else:
+                msg += "."
+            self._print(msg)
             # If an output is defined we return the result in the expected format
             if self.app.output:
                 return True, self._render_output(self.app.output, self._results)
@@ -135,12 +119,24 @@ class MigrateAddon(Output):
         if self.app.repo.is_dirty():
             # Same error message than git
             raise ValueError("You have unstaged changes. Please commit or stash them.")
+        # Start the migration
         self._checkout_base_branch()
+        if self.app.target.addon_path.exists():
+            # Corner case: target addon already exists as local folder, abort
+            self._print(
+                f"{bc.BOLD}{self.app.target.addon}{bc.END} local directory "
+                "(uncommitted) already exists, aborting."
+            )
+            return False, None
         confirm = (
-            f"Migrate {bc.BOLD}{self.app.addon}{bc.END} "
+            f"Migrate {bc.BOLD}{self.app.source.addon}{bc.END} "
             f"from {bc.BOLD}{self.app.source_version}{bc.END} "
-            f"to {bc.BOLD}{self.app.target_version}{bc.END}?"
+            f"to {bc.BOLD}{self.app.target_version}{bc.END}"
         )
+        if self.app.source.addon_path != self.app.target.addon_path:
+            confirm += f" and move it to {bc.BOLD}{self.app.target.addon_path}{bc.END}?"
+        else:
+            confirm += "?"
         if not click.confirm(confirm):
             self.app.storage.blacklist_addon(confirm=True)
             if not self.app.storage.dirty:
@@ -152,15 +148,19 @@ class MigrateAddon(Output):
                 self.app.storage.commit()
                 self._print_tips(blacklisted=True)
                 return False, None
+            # Port git history
             with tempfile.TemporaryDirectory() as patches_dir:
                 self._generate_patches(patches_dir)
                 self._apply_patches(patches_dir)
+            # Handle module move/renaming
+            if self.app.source.addon_path != self.app.target.addon_path:
+                self._move_addon()
             # Run pre-commit
             updated_files = g.run_pre_commit(self.app.repo)
             if updated_files:
                 g.commit(
                     self.app.repo,
-                    msg=f"[IMP] {self.app.addon}: pre-commit auto fixes",
+                    msg=f"[IMP] {self.app.target.addon}: pre-commit auto fixes",
                     paths=updated_files,
                 )
             # Adapt code thanks to odoo-module-migrator (if installed)
@@ -174,6 +174,74 @@ class MigrateAddon(Output):
         PortAddonPullRequest(self.app, push_branch=False).run()
         self._print_tips(adapted=adapted)
         return True, None
+
+    def _check_addon_already_migrated(self):
+        # if local:
+        #     # Check if addon exists as a local folder
+        #     # FIXME: this check should occurs once repo is checkout on target branch
+        #     source_addon_exists = self.app.source.addon_path.exists()
+        #     target_addon_exists = self.app.target.addon_path.exists()
+        #     if source_addon_exists or target_addon_exists:
+        #         addon = (
+        #             self.app.source.addon
+        #             if source_addon_exists
+        #             else self.app.target.addon
+        #         )
+        #         self._print(
+        #             f"{bc.BOLD}{addon}{bc.END} local directory (uncommitted) "
+        #             "already exists, aborting."
+        #         )
+        #         return False
+        # Check if addon exists in git trees (=> already migrated)
+        source_addon_exists = self.app._check_addon_exists(
+            self.app.source, self.app.to_branch
+        )
+        target_addon_exists = self.app._check_addon_exists(
+            self.app.target, self.app.to_branch
+        )
+        if source_addon_exists or target_addon_exists:
+            addon = (
+                self.app.source.addon if source_addon_exists else self.app.target.addon
+            )
+            self._results = {}  # Nothing to report
+            self._print(
+                f"{bc.BOLD}{addon}{bc.END} is already migrated "
+                f"on {bc.BOLD}{self.app.to_branch.ref()}{bc.END}, "
+                "aborting."
+            )
+            return True
+        return False
+
+    def _check_addon_blacklisted(self):
+        blacklisted = self.app.storage.is_addon_blacklisted()
+        if blacklisted:
+            self._results["results"]["blacklisted"] = True
+            self._print(
+                f"{bc.DIM}Migration of {bc.BOLD}{self.app.source.addon}{bc.END} "
+                f"{bc.DIM}to {self.app.to_branch.name} "
+                f"blacklisted ({blacklisted}){bc.ENDD}"
+            )
+        return blacklisted
+
+    def _detect_existing_pr(self):
+        """Looking for an existing PR to review."""
+        existing_pr = None
+        if self.app.upstream_org and self.app.repo_name:
+            existing_pr = self.app.github.search_migration_pr(
+                from_org=self.app.upstream_org,
+                repo_name=self.app.repo_name,
+                branch=self.app.target.branch,
+                addon=self.app.source.addon,
+            )
+        if existing_pr:
+            self._print(
+                f"⚠️\tMigration of {bc.BOLD}{self.app.source.addon}{bc.END} "
+                f"seems handled in this PR:\n"
+                f"\t\t{bc.BOLD}{existing_pr.url}{bc.END} (by {existing_pr.author})\n"
+                "\tWe invite you to review this PR instead of opening a new one. "
+                "Thank you!"
+            )
+            self._results["results"]["existing_pr"] = existing_pr.to_dict(number=True)
 
     def _checkout_base_branch(self):
         # Ensure to not start to work from a working branch
@@ -217,10 +285,11 @@ class MigrateAddon(Output):
             patches_dir,
             f"{self.app.to_branch.ref()}..{self.app.from_branch.ref()}",
             "--",
-            self.app.addon_path,
+            self.app.source.addon_path,
         )
 
     def _apply_patches(self, patches_dir):
+        # FIXME: rework patches paths if module has been moved/renamed
         patches = [
             os.path.join(patches_dir, f) for f in sorted(os.listdir(patches_dir))
         ]
@@ -228,15 +297,47 @@ class MigrateAddon(Output):
         print(f"\tApply {len(patches)} patches...")
         self.app.repo.git.am("-3", "--keep", *patches)
         print(
-            f"\t\tCommits history of {bc.BOLD}{self.app.addon}{bc.END} "
+            f"\t\tCommits history of {bc.BOLD}{self.app.source.addon}{bc.END} "
             f"has been migrated."
         )
+
+    def _move_addon(self):
+        print(
+            f"\Move module {bc.BOLD}{self.app.source.addon_path}{bc.END} "
+            f"to {bc.BOLD}{self.app.target.addon_path}{bc.END}..."
+        )
+        path_rename = f"{self.app.source.addon_path}:{self.app.target.addon_path}"
+        # Limit the rewriting of git history on current branch
+        refs = f"{self.app.target.ref}..{self.mig_branch.name}"
+        args = gfr.FilteringOptions.parse_args(
+            [
+                f"--path-rename={path_rename}",
+                "--refs",
+                refs,
+                "--force",
+            ]
+        )
+        filter_ = gfr.RepoFilter(args)
+        filter_.run()
+        if self.app.source.addon != self.app.target.addon:
+            update_terms_in_directory(
+                self.app.target.addon_path,
+                self.app.source.addon,
+                self.app.target.addon,
+            )
+        self.app.repo.git.add(self.app.target.addon_path)
+        if self.app.repo.is_dirty():
+            self.app.repo.git.commit(
+                "-m",
+                f"[MOV] Move {self.app.source.addon} to {self.app.target.addon}",
+                "--no-verify",
+            )
 
     def _print_tips(self, blacklisted=False, adapted=False):
         mig_tasks_url = MIG_TASKS_URL.format(version=self.app.target_version)
         pr_title_encoded = urllib.parse.quote(
             MIG_NEW_PR_TITLE.format(
-                version=self.app.target_version, addon=self.app.addon
+                version=self.app.target_version, addon=self.app.source.addon
             )
         )
         new_pr_url = MIG_NEW_PR_URL.format(
@@ -275,7 +376,7 @@ class MigrateAddon(Output):
         tips = steps.format(
             from_org=self.app.upstream_org,
             repo_name=self.app.repo_name,
-            addon=self.app.addon,
+            addon=self.app.source.addon,
             version=self.app.target_version,
             remote=self.app.destination.remote or "YOUR_REMOTE",
             mig_branch=self.mig_branch.name,
@@ -298,10 +399,10 @@ class MigrateAddon(Output):
 
         try:
             migration = Migration(
-                self.app.addons_rootdir,
+                self.app.target.addons_rootdir,
                 self.app.source_version,
                 self.app.target_version,
-                module_names=[self.app.addon],
+                module_names=[self.app.target.addon],
                 pre_commit=False,
             )
             migration.run()

--- a/oca_port/tests/test_utils_git.py
+++ b/oca_port/tests/test_utils_git.py
@@ -1,0 +1,81 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from collections import namedtuple
+
+
+from . import common
+
+from oca_port.utils import git as g
+
+FakeCommit = namedtuple(
+    "FakeCommit",
+    [
+        "author",
+        "authored_datetime",
+        "summary",
+        "message",
+        "hexsha",
+        "committed_datetime",
+        "parents",
+        "stats",
+    ],
+)
+
+FakeAuthor = namedtuple("FakeAuthor", ["name", "email"])
+
+
+class TestGit(common.CommonCase):
+    def setUp(self):
+        super().setUp()
+        self.repo = self._git_repo(self.repo_upstream_path)
+        self.branch1 = self.source1.split("/")[1]
+        self.branch2 = self.source2.split("/")[1]
+
+    def test_same_commit_eq(self):
+        raw_commit = self.repo.refs[self.branch1].commit
+        c1 = g.Commit(raw_commit)
+        c2 = g.Commit(raw_commit)
+        self.assertEqual(c1, c2)
+
+    def test_different_commit_not_eq(self):
+        raw_commit1 = self.repo.refs["17.0"].commit
+        # On 18.0 branch, last commit is renaming a module,
+        # so different than last commit on 17.0
+        raw_commit2 = self.repo.refs["18.0"].commit
+        c1 = g.Commit(raw_commit1)
+        c2 = g.Commit(raw_commit2)
+        self.assertNotEqual(c1, c2)
+
+    def test_different_commit_eq(self):
+        raw_commit1_sha = self._commit_change_on_branch(
+            self.repo_upstream_path, self.branch1
+        )
+        raw_commit1 = self.repo.commit(raw_commit1_sha)
+        raw_commit2_sha = self._commit_change_on_branch(
+            self.repo_upstream_path, self.branch2
+        )
+        raw_commit2 = self.repo.commit(raw_commit2_sha)
+        c1 = g.Commit(raw_commit1)
+        c2 = g.Commit(raw_commit2)
+        self.assertEqual(c1, c2)
+
+    def test_different_commit_eq_paths(self):
+        """Test commit comparison on a module renamed with 'git mv'."""
+        # Commit "[ADD] my_module"
+        raw_commit1 = self.repo.refs[self.branch1].commit
+        # Create the same commit through a cherry-pick + amend to rename the
+        # module, but all other commit attributes are the same
+        self.repo.git.checkout("--orphan", "TEST")
+        self.repo.git.reset("--hard")
+        self.repo.git.cherry_pick(raw_commit1.hexsha)
+        self.repo.git.mv(self.addon, self.target_addon)
+        self.repo.git.commit("--amend", "--no-edit")
+        raw_commit2 = self.repo.refs["TEST"].commit
+        # Compare them
+        eq_paths = {self.addon: self.target_addon}
+        c1 = g.Commit(raw_commit1, eq_paths=eq_paths)
+        c2 = g.Commit(raw_commit2, eq_paths=eq_paths)
+        self.assertEqual(c1, c2)
+        self.assertEqual(c1.paths, c2.paths)
+        self.assertNotEqual(c1.files, c2.files)  # Different file paths updated

--- a/oca_port/utils/cache.py
+++ b/oca_port/utils/cache.py
@@ -120,7 +120,7 @@ class UserCache:
     def _get_ported_commits_path(self):
         """Return the file path storing ported commit."""
         file_name = (
-            f"{self.app.addon}_{self.app.source.repo}_{self.app.from_branch.name}_"
+            f"{self.app.source.addon}_{self.app.source.repo}_{self.app.from_branch.name}_"
             f"to_{self.app.target.repo}_{self.app.to_branch.name}.list"
         )
         return self.dir_path.joinpath(
@@ -132,7 +132,7 @@ class UserCache:
     def _get_commits_to_port_path(self):
         """Return the file path storing cached data of commits to port."""
         file_name = (
-            f"{self.app.addon}_{self.app.source.repo}_{self.app.from_branch.name}_"
+            f"{self.app.source.addon}_{self.app.source.repo}_{self.app.from_branch.name}_"
             f"to_{self.app.target.repo}_{self.app.to_branch.name}.json"
         )
         return self.dir_path.joinpath(

--- a/oca_port/utils/misc.py
+++ b/oca_port/utils/misc.py
@@ -3,9 +3,13 @@
 
 import giturlparse
 import json
+import logging
 import os
 import re
+import subprocess
 from collections import defaultdict
+
+_logger = logging.getLogger(__name__)
 
 MANIFEST_NAMES = ("__manifest__.py", "__openerp__.py")
 
@@ -125,3 +129,22 @@ def pr_ref_from_url(url):
     # url like 'https://github.com/OCA/edi/pull/371'
     org, repo, __, nr = url.split("/")[3:]
     return f"{org}/{repo}#{nr}"
+
+
+def update_terms_in_directory(dir_path, old_term, new_term):
+    """Update all `old_term` terms to `new_term` in `dir_path` directory."""
+    # NOTE: requires 'find' and 'sed' tools available
+    cmd = [
+        "find",
+        str(dir_path),
+        "-type f",
+        "! -name __init__.py",
+        "-exec",
+        f"sed -i 's/{old_term}/{new_term}/g'" + " {} \;",
+    ]
+    try:
+        subprocess.check_call(" ".join(cmd), shell=True)
+    except subprocess.CalledProcessError:
+        _logger.warning(
+            f"⚠️  Unable to rename '{old_term}' terms to '{new_term}' in {dir_path} directory"
+        )

--- a/oca_port/utils/session.py
+++ b/oca_port/utils/session.py
@@ -27,7 +27,7 @@ class Session:
         self._sessions_dir_path = self._get_sessions_dir_path()
         self._key = hashlib.shake_256(name.encode()).hexdigest(3)
         session_file = (
-            f"{self.app.addon}"
+            f"{self.app.source.addon}"
             f"-{self.app.source_version}-{self.app.target_version}"
             f"-{self._key}.json"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "gitpython",
     "requests",
     "giturlparse",
+    "git-filter-repo",
 ]
 requires-python = ">=3.8"
 dynamic = ["version"]


### PR DESCRIPTION
Different approach than #64 to move/rename a module to address issue #11:

- [x] new module name is given as an optional parameter: `oca-port {source} {target} {addon_path} [--move-to {new_addon_path}]`
- [x] store the old name + new name in source/target data object
- [x] move/rename a module once the git history is retrieved (with `git-filter-repo`, thanks for the tip @trisdoan )
- [x] <s>use `git filter-branch` to rename the module (see https://github.com/OCA/commission/pull/610#issuecomment-2834244381)</s>
- [x] rename terms in the renamed modules (in PO files, XML-ID references...)
- [x]  :construction:  adapt `PortAddonPullRequest` to work on moved/renamed module (rework patches to apply to target the new module/folder name, ...)

Optional (can be done in a future PR):
- [ ] store this info in `.oca/oca-port/` directory with `Storage` class
- [ ] read data stored in `.oca/oca-port/` so a migration attempt will automatically detect that this module has been renamed in target branch, launching analysis with the right module name

### Example

Migrate & rename a module at the same time:
```sh
$ oca-port origin/17.0 origin/18.0 stock_packaging_calculator --move-to product_packaging_calculator --dry-run
ℹ️  stock_packaging_calculator can be migrated from 16.0 to 18.0 and moved to product_packaging_calculator
```

<s>
Module already migrated under a different name:
```sh
$ oca-port origin/17.0 origin/18.0 stock_packaging_calculator
ℹ️ stock_packaging_calculator has been renamed product_packaging_calculator in origin/18.0
product_packaging_calculator already exists on origin/18.0, checking PRs to port...
```
</s>