### PR TITLE
[IMP] Allow untracked files in repository, like any git command

### DIFF
--- a/oca_port/app.py
+++ b/oca_port/app.py
@@ -145,8 +145,9 @@ class App(Output):
     def _prepare_parameters(self):
         # Handle Git repository
         self.repo = git.Repo(self.repo_path)
-        if self.repo.is_dirty(untracked_files=True):
-            raise ValueError("changes not committed detected in this repository.")
+        if self.repo.is_dirty():
+            # Same error message than git
+            raise ValueError("You have unstaged changes. Please commit or stash them.")
 
         # Module name
         self.addon_path = pathlib.Path(self.addon_path)

--- a/oca_port/migrate_addon.py
+++ b/oca_port/migrate_addon.py
@@ -132,6 +132,10 @@ class MigrateAddon(Output):
                 # Allocate 110 for 'PortAddonPullRequest'.
                 raise SystemExit(100)
             return True, None
+        if self.app.repo.is_dirty():
+            # Same error message than git
+            raise ValueError("You have unstaged changes. Please commit or stash them.")
+        self._checkout_base_branch()
         confirm = (
             f"Migrate {bc.BOLD}{self.app.addon}{bc.END} "
             f"from {bc.BOLD}{self.app.source_version}{bc.END} "
@@ -141,9 +145,6 @@ class MigrateAddon(Output):
             self.app.storage.blacklist_addon(confirm=True)
             if not self.app.storage.dirty:
                 return False, None
-        if self.app.repo.untracked_files:
-            raise click.ClickException("Untracked files detected, abort")
-        self._checkout_base_branch()
         adapted = False
         if self._create_mig_branch():
             # Case where the addon shouldn't be ported (blacklisted)


### PR DESCRIPTION
If an untracked file gets in conflict with a patch, an error will be raised anyway. Up to the user to do some cleanup before re-trying.

Extracted from #74 