### PR TITLE
PortAddonPullRequest: fix `print_satellite_diff()`, use whole rootdir path

### DIFF
--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -760,7 +760,7 @@ class BranchesDiff(Output):
                 self.app.repo,
                 self.app.to_branch.ref(),
                 path,
-                rootdir=self.app.addons_rootdir and self.app.addons_rootdir.name,
+                rootdir=self.app.addons_rootdir and str(self.app.addons_rootdir),
             )
             if path_exists:
                 if verbose:


### PR DESCRIPTION
This is currently failing when working on module path like `a/b/{module}`