### PR TITLE
MigrateAddon: ensure to run pre-commit

### DIFF
--- a/oca_port/migrate_addon.py
+++ b/oca_port/migrate_addon.py
@@ -160,7 +160,9 @@ class MigrateAddon(Output):
                 metadata.metadata("odoo-module-migrator")
                 adapted = self._apply_code_pattern()
             except metadata.PackageNotFoundError:
-                g.run_pre_commit(self.app.repo, self.app.addon)
+                pass
+        if not adapted:
+            g.run_pre_commit(self.app.repo, self.app.addon)
         # Check if the addon has commits that update neighboring addons to
         # make it work properly
         PortAddonPullRequest(self.app, push_branch=False).run()


### PR DESCRIPTION
`odoo-module-migrator` is able to run pre-commit, but if he didn't run as expected, 'oca-port' has to run it by itself.