### PR TITLE
[FIX] utils.github.get_original_pr() and utils.git.check_path_exists()

### DIFF
--- a/oca_port/utils/git.py
+++ b/oca_port/utils/git.py
@@ -336,7 +336,7 @@ def get_changed_paths(repo, modified=True, staged=True):
 
 def check_path_exists(repo, ref, path, rootdir=None):
     root_tree = repo.commit(ref).tree
-    if rootdir:
+    if rootdir and rootdir != ".":
         root_tree /= str(rootdir)
     paths = [t.path for t in root_tree.trees]
     return path in paths

--- a/oca_port/utils/github.py
+++ b/oca_port/utils/github.py
@@ -41,15 +41,16 @@ class GitHub:
         gh_commit_pulls = self.request(
             f"repos/{from_org}/{repo_name}/commits/{commit_sha}/pulls"
         )
-        gh_commit_pull = [
-            data
-            for data in gh_commit_pulls
+        for data in gh_commit_pulls:
             if (
                 data["base"]["ref"] == branch
                 and data["base"]["repo"]["full_name"] == f"{from_org}/{repo_name}"
-            )
-        ]
-        return gh_commit_pull and gh_commit_pull[0] or {}
+            ):
+                data2 = self.request(data["commits_url"].replace(GITHUB_API_URL, ""))
+                pr_commits = [d["sha"] for d in data2]
+                if commit_sha in pr_commits:
+                    return data
+        return {}
 
     def search_migration_pr(
         self, from_org: str, repo_name: str, branch: str, addon: str


### PR DESCRIPTION
When requesting GH API to found the original PR of a given commit, wrong PR references could be returned, like here:
https://github.com/OCA/wms/commit/3fc53bb2ea9359f658d2c1196bf5321d4b615b1c

PR OCA/wms#31 is the right one, while OCA/wms#980 is unrelated. To workaround this, we check if the commit is part of the PR commits, ensuring the right PR is returned at the end (if any).

It could be that existing user's cache could contain such wrong results, and `oca-port` won't report the expecting PRs/commits to port in such situation. Clearing the cache with `--clear-cache` is then mandatory.