### PR TITLE
feat: Use git cherry-pick instead of git am

### DIFF
--- a/oca_port/port_addon_pr.py
+++ b/oca_port/port_addon_pr.py
@@ -421,33 +421,7 @@ class PortAddonPullRequest(Output):
                 self._print("\t\t\tℹ️  Nothing to port from this commit, skipping")
                 continue
             try:
-                # Generate patches to port from source module
-                patches_dir = tempfile.mkdtemp()
-                self.app.repo.git.format_patch(
-                    "--keep-subject",
-                    "-o",
-                    patches_dir,
-                    "-1",
-                    commit.hexsha,
-                    "--",
-                    *paths_to_port,
-                )
-                patches = [
-                    os.path.join(patches_dir, f)
-                    for f in sorted(os.listdir(patches_dir))
-                ]
-                # Apply patches on target module (could be the same than source one
-                # or a new one if it has been renamed).
-                n_leading_paths = len(self.app.source.addon_path.parts) + 1
-                self.app.repo.git.am(
-                    "-3",
-                    "--keep",
-                    *patches,
-                    f"-p{n_leading_paths}",  # Remove 'a/my_module' from patch
-                    "--directory",
-                    self.app.target.addon_path,  # Prepend 'my_module[_renamed]' to patch
-                )
-                shutil.rmtree(patches_dir)
+                self.app.repo.git.cherry_pick(commit.hexsha)
             except git.exc.GitCommandError as exc:
                 self._print(f"{bc.FAIL}ERROR:{bc.ENDC}\n{exc}\n")
                 # High chance a conflict occurs, ask the user to resolve it
@@ -455,7 +429,7 @@ class PortAddonPullRequest(Output):
                     "⚠️  A conflict occurs, please resolve it and "
                     "confirm to continue the process (y) or skip this commit (N)."
                 ):
-                    self.app.repo.git.am("--abort")
+                    self.app.repo.git.cherry_pick("--abort")
                     continue
         return True
 


### PR DESCRIPTION
as I explain here #60, oca-port is currently not taking advantage of a killer merge conflict resolution tool: [mergiraf](https://mergiraf.org/).

This can change if we use git cherry-pick instead of git am in oca-port because cherry-pick has more merging context so mergiraf is kickin'in.

I used it this way for my last porting PRs in OCA/l10n-brazil. But if you prefer I can also craft is as an option. What do you think?

cc @sebalix @simahawk @sbidoul @renatonlima @sebastienbeau @hparfr 

